### PR TITLE
delete reset_password_email_sent_at when change_password

### DIFF
--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -123,6 +123,7 @@ module Sorcery
           def clear_reset_password_token
             config = sorcery_config
             self.send(:"#{config.reset_password_token_attribute_name}=", nil)
+            self.send(:"#{config.reset_password_email_sent_at_attribute_name}=", nil)
             self.send(:"#{config.reset_password_token_expires_at_attribute_name}=", nil) if config.reset_password_expiration_period
           end
         end

--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -247,6 +247,7 @@ shared_examples_for "rails_3_reset_password_model" do
       user.save!
 
       expect(user.reset_password_token).to be_nil
+      expect(user.reset_password_email_sent_at).to be_nil
     end
 
     it "returns false if time between emails has not passed since last email" do


### PR DESCRIPTION
I fixed that reset_password_email_sent_at isn't nil when the change_password!.
because, can't sent a mail at the time of the second time.
