### PR TITLE
 There remains left users and version in schema_migrations after running test suites.

### DIFF
--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -237,6 +237,7 @@ describe SorceryController, :active_record => true do
 
     after(:all) do
       if SORCERY_ORM == :active_record
+        ActiveRecord::Migrator.rollback("#{Rails.root}/db/migrate/external")
         ActiveRecord::Migrator.rollback("#{Rails.root}/db/migrate/activation")
       end
     end

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -532,8 +532,8 @@ shared_examples_for "external_user" do
 
     after(:all) do
       if SORCERY_ORM == :active_record
-        ActiveRecord::Migrator.rollback("#{Rails.root}/db/migrate/activation")
         ActiveRecord::Migrator.rollback("#{Rails.root}/db/migrate/external")
+        ActiveRecord::Migrator.rollback("#{Rails.root}/db/migrate/activation")
       end
     end
 


### PR DESCRIPTION
# About the bug
After run specs, there remains left users and version in schema_migrations.
```
sqlite> .tables
schema_migrations  users
sqlite>
sqlite> select * from users;
sqlite>
sqlite> select * from schema_migrations;
20101224223620
20101224223622
```
It prevents from running test suites after modifying a file in `spec/rails_app/db/migrate/core` or `spec/rails_app/db/migrate/activation`.

# How to fix
Looking into specs, I found 2 files `spec/controllers/controller_oauth2_spec.rb` and  `spec/shared_examples/user_shared_examples.rb` are the cause.

First in `spec/controllers/controller_oauth2_spec.rb`, I add rollback of external just before rollback of activation. The current version when rollback of activation is exectuted is different.
The versions then is below:
```
sqlite> select * from schema_migrations;
20101224223620
20101224223628
20101224223622
```


Secondly in `spec/shared_examples/user_shared_examples.rb`, I modify the order of rollbacks because of the similar reason. The current version when rollback of activation is the version of external. Need rollback of external first, then rollback activation.

I test all suites by running 'rspec'.

# Result
The results below is the conditions of sqlite after running specs.

before
```
sqlite> .tables
schema_migrations  users
sqlite>
sqlite> select * from users;
sqlite>
sqlite> select * from schema_migrations;
20101224223620
20101224223622
sqlite>
```

after
```
sqlite> .tables
schema_migrations
sqlite>
sqlite> select * from schema_migrations;
sqlite>
```
