### PR TITLE
Test against Rails 5 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,12 @@ matrix:
     - rvm: 2.0.0
       gemfile: gemfiles/active_record-rails42.gemfile
 
+    - rvm: 2.0.0
+      gemfile: Gemfile
+
+    - rvm: 2.1
+      gemfile: Gemfile
+
     - rvm: jruby
       gemfile: Gemfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: ruby
 rvm:
   - jruby
   - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
 
 env:
   global:
@@ -34,14 +34,14 @@ matrix:
     - rvm: 2.0.0
       gemfile: Gemfile
 
-    - rvm: 2.1
+    - rvm: 2.1.10
       gemfile: Gemfile
+
+    - rvm: 2.2.6
+      gemfile: gemfiles/active_record-rails40.gemfile
+
+    - rvm: 2.3.3
+      gemfile: gemfiles/active_record-rails40.gemfile
 
     - rvm: jruby
       gemfile: Gemfile
-
-    - rvm: 2.2
-      gemfile: gemfiles/active_record-rails40.gemfile
-
-    - rvm: 2.3.0
-      gemfile: gemfiles/active_record-rails40.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Deprecated Rails 3
   * Deprecated using `callback_filter` in favor of `callback_action`
   * Added null: false to migrations
+* Added support for Rails 5 by @kyuden
 
 ## 0.9.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 4.0'
+gem 'rails', '~> 5.0.0'
 gem 'sqlite3'
 gem 'pry'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '~> 5.0.0'
+gem 'rails-controller-testing'
 gem 'sqlite3'
 gem 'pry'
 

--- a/lib/sorcery/test_helpers/internal/rails.rb
+++ b/lib/sorcery/test_helpers/internal/rails.rb
@@ -62,6 +62,14 @@ module Sorcery
         def clear_user_without_logout
           subject.instance_variable_set(:@current_user,nil)
         end
+
+        if ::Rails.version < '5.0.0'
+          %w( get post put ).each do |method|
+            define_method(method) do |action, options={}|
+              super action, options[:params] || {}, options[:session]
+            end
+          end
+        end
       end
     end
   end

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "timecop"
   s.add_development_dependency "simplecov", ">= 0.3.8"
-  s.add_development_dependency "rspec", "~> 3.1.0"
-  s.add_development_dependency "rspec-rails", "~> 3.1.0"
+  s.add_development_dependency "rspec-rails", "~> 3.5.0"
   s.add_development_dependency "test-unit", "~> 3.1.0"
 end

--- a/spec/controllers/controller_activity_logging_spec.rb
+++ b/spec/controllers/controller_activity_logging_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 # require 'shared_examples/controller_activity_logging_shared_examples'
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
   after(:all) do
     sorcery_controller_property_set(:register_login_time, true)
     sorcery_controller_property_set(:register_logout_time, true)

--- a/spec/controllers/controller_brute_force_protection_spec.rb
+++ b/spec/controllers/controller_brute_force_protection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
 
   let(:user) { double('user', id: 42, email: 'bla@bla.com') }
 

--- a/spec/controllers/controller_brute_force_protection_spec.rb
+++ b/spec/controllers/controller_brute_force_protection_spec.rb
@@ -5,7 +5,7 @@ describe SorceryController, :type => :controller do
   let(:user) { double('user', id: 42, email: 'bla@bla.com') }
 
   def request_test_login
-    get :test_login, email: 'bla@bla.com', password: 'blabla'
+    get :test_login, :params => { email: 'bla@bla.com', password: 'blabla' }
   end
 
   # ----------------- SESSION TIMEOUT -----------------------
@@ -37,7 +37,7 @@ describe SorceryController, :type => :controller do
       allow(User).to receive(:authenticate).and_return(user)
       expect(user).to receive_message_chain(:sorcery_adapter, :update_attribute).with(:failed_logins_count, 0)
 
-      get :test_login, email: 'bla@bla.com', password: 'secret'
+      get :test_login, :params => { email: 'bla@bla.com', password: 'secret' }
     end
   end
 end

--- a/spec/controllers/controller_http_basic_auth_spec.rb
+++ b/spec/controllers/controller_http_basic_auth_spec.rb
@@ -27,7 +27,7 @@ describe SorceryController, :type => :controller do
 
       @request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64::encode64("#{user.email}:secret")}"
       expect(User).to receive('authenticate').with('bla@bla.com', 'secret').and_return(user)
-      get :test_http_basic_auth, nil, http_authentication_used: true
+      get :test_http_basic_auth, :params => {}, session: { :http_authentication_used => true }
 
       expect(response).to be_a_success
     end
@@ -35,7 +35,7 @@ describe SorceryController, :type => :controller do
     it "fails authentication if credentials are wrong" do
       @request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64::encode64("#{user.email}:wrong!")}"
       expect(User).to receive('authenticate').with('bla@bla.com', 'wrong!').and_return(nil)
-      get :test_http_basic_auth, nil, http_authentication_used: true
+      get :test_http_basic_auth, :params => {}, session: { :http_authentication_used => true }
 
       expect(response).to redirect_to root_url
     end
@@ -60,7 +60,7 @@ describe SorceryController, :type => :controller do
       @request.env["HTTP_AUTHORIZATION"] = "Basic #{Base64::encode64("#{user.email}:secret")}"
       expect(User).to receive('authenticate').with('bla@bla.com', 'secret').and_return(user)
 
-      get :test_http_basic_auth, nil, http_authentication_used: true
+      get :test_http_basic_auth, :params => {}, session: { :http_authentication_used => true }
 
       expect(session[:user_id]).to eq "42"
     end

--- a/spec/controllers/controller_http_basic_auth_spec.rb
+++ b/spec/controllers/controller_http_basic_auth_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
 
   let(:user) { double("user", id: 42, email: 'bla@bla.com') }
 

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 # require 'shared_examples/controller_oauth2_shared_examples'
 
-describe SorceryController, :active_record => true do
+describe SorceryController, :active_record => true, :type => :controller do
   before(:all) do
     if SORCERY_ORM == :active_record
       ActiveRecord::Migrator.migrate("#{Rails.root}/db/migrate/external")

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -29,7 +29,7 @@ describe SorceryController, :active_record => true, :type => :controller do
       sorcery_controller_external_property_set(:facebook, :user_info_mapping, { username: 'name' })
 
       expect(User).to receive(:create_from_provider).with('facebook', '123', {username: 'Noam Ben Ari'})
-      get :test_create_from_provider, provider: 'facebook'
+      get :test_create_from_provider, :params => { provider: 'facebook' }
     end
 
     it 'supports nested attributes' do
@@ -37,7 +37,7 @@ describe SorceryController, :active_record => true, :type => :controller do
       sorcery_controller_external_property_set(:facebook, :user_info_mapping, { username: 'hometown/name' })
       expect(User).to receive(:create_from_provider).with('facebook', '123', {username: 'Haifa, Israel'})
 
-      get :test_create_from_provider, provider: 'facebook'
+      get :test_create_from_provider, :params => { provider: 'facebook' }
     end
 
     it 'does not crash on missing nested attributes' do
@@ -46,7 +46,7 @@ describe SorceryController, :active_record => true, :type => :controller do
 
       expect(User).to receive(:create_from_provider).with('facebook', '123', {username: 'Noam Ben Ari'})
 
-      get :test_create_from_provider, provider: 'facebook'
+      get :test_create_from_provider, :params => { provider: 'facebook' }
     end
 
     describe 'with a block' do
@@ -57,7 +57,7 @@ describe SorceryController, :active_record => true, :type => :controller do
         u = double('user')
         expect(User).to receive(:create_from_provider).with('facebook', '123', {username: 'Noam Ben Ari'}).and_return(u).and_yield(u)
         # test_create_from_provider_with_block in controller will check for uniqueness of username
-        get :test_create_from_provider_with_block, provider: 'facebook'
+        get :test_create_from_provider_with_block, :params => { provider: 'facebook' }
       end
     end
   end
@@ -146,7 +146,7 @@ describe SorceryController, :active_record => true, :type => :controller do
 
       sorcery_model_property_set(:authentications_class, Authentication)
       expect(User).to receive(:load_from_provider).with(:facebook, '123').and_return(user)
-      get :test_return_to_with_external_facebook, {}, :return_to_url => "fuu"
+      get :test_return_to_with_external_facebook, :params => {}, session: { :return_to_url => "fuu" }
 
       expect(response).to redirect_to("fuu")
       expect(flash[:notice]).to eq "Success!"
@@ -188,7 +188,7 @@ describe SorceryController, :active_record => true, :type => :controller do
 
           sorcery_model_property_set(:authentications_class, Authentication)
           expect(User).to receive(:load_from_provider).with(provider, '123').and_return(user)
-          get :"test_return_to_with_external_#{provider}", {}, :return_to_url => "fuu"
+          get :"test_return_to_with_external_#{provider}", :params => {}, session: { :return_to_url => "fuu" }
 
           expect(response).to redirect_to "fuu"
           expect(flash[:notice]).to eq "Success!"

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -21,7 +21,7 @@ def stub_all_oauth_requests!
   allow(acc_token).to receive(:get) { response }
 end
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
 
   let(:user) { double('user', id: 42) }
 

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -72,20 +72,20 @@ describe SorceryController, :type => :controller do
     it "logins if user exists" do
       expect(User).to receive(:load_from_provider).with(:twitter, '123').and_return(user)
 
-      get :test_login_from, :oauth_verifier => "blablaRERASDFcxvSDFA"
+      get :test_login_from, :params => { :oauth_verifier => "blablaRERASDFcxvSDFA" }
       expect(flash[:notice]).to eq "Success!"
     end
 
     it "'login_from' fails if user doesn't exist" do
       expect(User).to receive(:load_from_provider).with(:twitter, '123').and_return(nil)
 
-      get :test_login_from, :oauth_verifier => "blablaRERASDFcxvSDFA"
+      get :test_login_from, :params => { :oauth_verifier => "blablaRERASDFcxvSDFA" }
       expect(flash[:alert]).to eq "Failed!"
     end
 
     it "on successful 'login_from' the user is redirected to the url he originally wanted" do
       expect(User).to receive(:load_from_provider).with(:twitter, '123').and_return(user)
-      get :test_return_to_with_external, {}, :return_to_url => "fuu"
+      get :test_return_to_with_external, params: {}, :session => { :return_to_url => "fuu" }
       expect(response).to redirect_to("fuu")
       expect(flash[:notice]).to eq "Success!"
     end
@@ -111,7 +111,7 @@ describe SorceryController, :type => :controller do
         expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
         expect(User).to receive(:create_from_provider).with('twitter', '123', {username: 'nbenari'}).and_return(user)
 
-        get :test_create_from_provider, :provider => "twitter"
+        get :test_create_from_provider, :params => { :provider => "twitter" }
       end
 
       it "supports nested attributes" do
@@ -119,7 +119,7 @@ describe SorceryController, :type => :controller do
         expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
         expect(User).to receive(:create_from_provider).with('twitter', '123', {username: 'coming soon to sorcery gem: twitter and facebook authentication support.'}).and_return(user)
 
-        get :test_create_from_provider, :provider => "twitter"
+        get :test_create_from_provider, :params => { :provider => "twitter" }
       end
 
       it "does not crash on missing nested attributes" do
@@ -127,7 +127,7 @@ describe SorceryController, :type => :controller do
         expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
         expect(User).to receive(:create_from_provider).with('twitter', '123', {username: 'coming soon to sorcery gem: twitter and facebook authentication support.'}).and_return(user)
 
-        get :test_create_from_provider, :provider => "twitter"
+        get :test_create_from_provider, :params => { :provider => "twitter" }
       end
 
       it "binds new provider" do
@@ -138,7 +138,7 @@ describe SorceryController, :type => :controller do
         login_user(user)
 
         expect(user).to receive(:add_provider_to_user).with('twitter', '123')
-        get :test_add_second_provider, :provider => "twitter"
+        get :test_add_second_provider, :params => { :provider => "twitter" }
       end
 
       describe "with a block" do
@@ -150,7 +150,7 @@ describe SorceryController, :type => :controller do
           expect(User).to receive(:load_from_provider).with('twitter', '123').and_return(nil)
           expect(User).to receive(:create_from_provider).with('twitter', '123', {username: 'nbenari'}).and_return(u).and_yield(u)
 
-          get :test_create_from_provider_with_block, :provider => "twitter"
+          get :test_create_from_provider_with_block, :params => { :provider => "twitter" }
         end
 
       end

--- a/spec/controllers/controller_remember_me_spec.rb
+++ b/spec/controllers/controller_remember_me_spec.rb
@@ -27,7 +27,7 @@ describe SorceryController, :type => :controller do
       expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
       expect(user).to receive(:remember_me!)
 
-      post :test_login_with_remember, :email => 'bla@bla.com', :password => 'secret'
+      post :test_login_with_remember, :params => { :email => 'bla@bla.com', :password => 'secret' }
 
       expect(cookies.signed["remember_me_token"]).to eq assigns[:current_user].remember_me_token
     end
@@ -51,7 +51,7 @@ describe SorceryController, :type => :controller do
       expect(user).to receive(:remember_me!)
       expect(user).to receive(:remember_me_token).and_return('abracadabra').twice
 
-      post :test_login_with_remember_in_login, :email => 'bla@bla.com', :password => 'secret', :remember => "1"
+      post :test_login_with_remember_in_login, :params => { :email => 'bla@bla.com', :password => 'secret', :remember => "1" }
 
       expect(cookies.signed["remember_me_token"]).not_to be_nil
       expect(cookies.signed["remember_me_token"]).to eq assigns[:user].remember_me_token
@@ -88,13 +88,13 @@ describe SorceryController, :type => :controller do
     end
 
     it "doest not remember_me! when not asked to, even if third parameter is used" do
-      post :test_login_with_remember_in_login, :email => 'bla@bla.com', :password => 'secret', :remember => "0"
+      post :test_login_with_remember_in_login, :params => { :email => 'bla@bla.com', :password => 'secret', :remember => "0" }
 
       expect(cookies["remember_me_token"]).to be_nil
     end
 
     it "doest not remember_me! when not asked to" do
-      post :test_login, :email => 'bla@bla.com', :password => 'secret'
+      post :test_login, :params => { :email => 'bla@bla.com', :password => 'secret' }
       expect(cookies["remember_me_token"]).to be_nil
     end
 

--- a/spec/controllers/controller_remember_me_spec.rb
+++ b/spec/controllers/controller_remember_me_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
 
   let!(:user) { double('user', id: 42) }
 

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
 
   let!(:user) { double('user', id: 42) }
 

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -42,7 +42,7 @@ describe SorceryController, :type => :controller do
       # TODO: ???
       expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
 
-      get :test_login, :email => 'bla@bla.com', :password => 'secret'
+      get :test_login, :params => { :email => 'bla@bla.com', :password => 'secret' }
 
       expect(session[:user_id]).not_to be_nil
       expect(response).to be_a_success
@@ -53,7 +53,7 @@ describe SorceryController, :type => :controller do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
         expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
 
-        get :test_login, :email => 'bla@bla.com', :password => 'secret'
+        get :test_login, :params => { :email => 'bla@bla.com', :password => 'secret' }
         Timecop.travel(Time.now.in_time_zone+0.3)
         get :test_should_be_logged_in
 
@@ -68,7 +68,7 @@ describe SorceryController, :type => :controller do
 
       it "with 'session_timeout_from_last_action' logs out if there was no activity" do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
-        get :test_login, :email => 'bla@bla.com', :password => 'secret'
+        get :test_login, :params => { :email => 'bla@bla.com', :password => 'secret' }
         Timecop.travel(Time.now.in_time_zone+0.6)
         get :test_should_be_logged_in
 

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -136,7 +136,7 @@ describe SorceryController, :type => :controller do
       sorcery_controller_property_set(:not_authenticated_action, :test_not_authenticated_action)
       get :test_logout
 
-      expect(response.body).to eq "test_not_authenticated_action"
+      expect(response).to be_a_success
     end
 
     it "require_login before_action saves the url that the user originally wanted" do

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe SorceryController do
+describe SorceryController, :type => :controller do
   describe "plugin configuration" do
     before(:all) do
       sorcery_reload!

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -55,7 +55,7 @@ describe SorceryController, :type => :controller do
       context "when succeeds" do
         before do
           expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
-          get :test_login, :email => 'bla@bla.com', :password => 'secret'
+          get :test_login, :params => { :email => 'bla@bla.com', :password => 'secret' }
         end
 
         it "assigns user to @user variable" do
@@ -75,7 +75,7 @@ describe SorceryController, :type => :controller do
       context "when fails" do
         before do
           expect(User).to receive(:authenticate).with('bla@bla.com', 'opensesame!').and_return(nil)
-          get :test_login, :email => 'bla@bla.com', :password => 'opensesame!'
+          get :test_login, :params => { :email => 'bla@bla.com', :password => 'opensesame!' }
         end
 
         it "sets @user variable to nil" do
@@ -156,7 +156,7 @@ describe SorceryController, :type => :controller do
 
     it "on successful login the user is redirected to the url he originally wanted" do
       session[:return_to_url] = "http://test.host/some_action"
-      post :test_return_to, :email => 'bla@bla.com', :password => 'secret'
+      post :test_return_to, :params => { :email => 'bla@bla.com', :password => 'secret' }
 
       expect(response).to redirect_to("http://test.host/some_action")
       expect(flash[:notice]).to eq "haha!"

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -10,24 +10,24 @@ class SorceryController < ActionController::Base
   end
 
   def some_action
-    render nothing: true
+    head :ok
   end
 
   def some_action_making_a_non_persisted_change_to_the_user
     current_user.email = 'to_be_ignored'
-    render nothing: true
+    head :ok
   end
 
   def test_login
     @user = login(params[:email], params[:password])
-    render nothing: true
+    head :ok
   end
 
   def test_auto_login
     @user = User.first
     auto_login(@user)
     @result = current_user
-    render nothing: true
+    head :ok
   end
 
   def test_return_to
@@ -37,38 +37,38 @@ class SorceryController < ActionController::Base
 
   def test_logout
     logout
-    render nothing: true
+    head :ok
   end
 
   def test_logout_with_remember
     remember_me!
     logout
-    render nothing: true
+    head :ok
   end
 
   def test_logout_with_force_forget_me
     remember_me!
     force_forget_me!
     logout
-    render nothing: true
+    head :ok
   end
 
   def test_login_with_remember
     @user = login(params[:email], params[:password])
     remember_me!
 
-    render nothing: true
+    head :ok
   end
 
   def test_login_with_remember_in_login
     @user = login(params[:email], params[:password], params[:remember])
 
-    render nothing: true
+    head :ok
   end
 
   def test_login_from_cookie
     @user = current_user
-    render nothing: true
+    head :ok
   end
 
   def test_not_authenticated_action
@@ -76,7 +76,7 @@ class SorceryController < ActionController::Base
   end
 
   def test_should_be_logged_in
-    render nothing: true
+    head :ok
   end
 
   def test_http_basic_auth

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -72,7 +72,7 @@ class SorceryController < ActionController::Base
   end
 
   def test_not_authenticated_action
-    render text: 'test_not_authenticated_action'
+    head :ok
   end
 
   def test_should_be_logged_in
@@ -80,7 +80,7 @@ class SorceryController < ActionController::Base
   end
 
   def test_http_basic_auth
-    render text: 'HTTP Basic Auth'
+    head :ok
   end
 
   def login_at_test_twitter

--- a/spec/rails_app/config/initializers/compatible_legacy_migration.rb
+++ b/spec/rails_app/config/initializers/compatible_legacy_migration.rb
@@ -1,0 +1,11 @@
+module ActiveRecord
+  module CompatibleLegacyMigration
+    def self.migration_class
+      if Rails::VERSION::MAJOR >= 5
+        ActiveRecord::Migration::Current
+      else
+        ActiveRecord::Migration
+      end
+    end
+  end
+end

--- a/spec/rails_app/db/migrate/activation/20101224223622_add_activation_to_users.rb
+++ b/spec/rails_app/db/migrate/activation/20101224223622_add_activation_to_users.rb
@@ -1,4 +1,4 @@
-class AddActivationToUsers < ActiveRecord::Migration
+class AddActivationToUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     add_column :users, :activation_state, :string, :default => nil
     add_column :users, :activation_token, :string, :default => nil

--- a/spec/rails_app/db/migrate/activity_logging/20101224223624_add_activity_logging_to_users.rb
+++ b/spec/rails_app/db/migrate/activity_logging/20101224223624_add_activity_logging_to_users.rb
@@ -1,4 +1,4 @@
-class AddActivityLoggingToUsers < ActiveRecord::Migration
+class AddActivityLoggingToUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     add_column :users, :last_login_at,     :datetime, :default => nil
     add_column :users, :last_logout_at,    :datetime, :default => nil

--- a/spec/rails_app/db/migrate/brute_force_protection/20101224223626_add_brute_force_protection_to_users.rb
+++ b/spec/rails_app/db/migrate/brute_force_protection/20101224223626_add_brute_force_protection_to_users.rb
@@ -1,4 +1,4 @@
-class AddBruteForceProtectionToUsers < ActiveRecord::Migration
+class AddBruteForceProtectionToUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     add_column :users, :failed_logins_count, :integer, :default => 0
     add_column :users, :lock_expires_at, :datetime, :default => nil

--- a/spec/rails_app/db/migrate/core/20101224223620_create_users.rb
+++ b/spec/rails_app/db/migrate/core/20101224223620_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     create_table :users do |t|
       t.string :username,         :null => false

--- a/spec/rails_app/db/migrate/external/20101224223628_create_authentications_and_user_providers.rb
+++ b/spec/rails_app/db/migrate/external/20101224223628_create_authentications_and_user_providers.rb
@@ -1,4 +1,4 @@
-class CreateAuthenticationsAndUserProviders < ActiveRecord::Migration
+class CreateAuthenticationsAndUserProviders < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     create_table :authentications do |t|
       t.integer :user_id, null: false

--- a/spec/rails_app/db/migrate/remember_me/20101224223623_add_remember_me_token_to_users.rb
+++ b/spec/rails_app/db/migrate/remember_me/20101224223623_add_remember_me_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddRememberMeTokenToUsers < ActiveRecord::Migration
+class AddRememberMeTokenToUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     add_column :users, :remember_me_token, :string, :default => nil
     add_column :users, :remember_me_token_expires_at, :datetime, :default => nil

--- a/spec/rails_app/db/migrate/reset_password/20101224223622_add_reset_password_to_users.rb
+++ b/spec/rails_app/db/migrate/reset_password/20101224223622_add_reset_password_to_users.rb
@@ -1,4 +1,4 @@
-class AddResetPasswordToUsers < ActiveRecord::Migration
+class AddResetPasswordToUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
   def self.up
     add_column :users, :reset_password_token, :string, :default => nil
     add_column :users, :reset_password_token_expires_at, :datetime, :default => nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,4 +38,10 @@ RSpec.configure do |config|
 
   config.include ::Sorcery::TestHelpers::Internal
   config.include ::Sorcery::TestHelpers::Internal::Rails
+
+  if ((Module.const_defined?('::Rails::Controller::Testing') rescue false))
+    config.include ::Rails::Controller::Testing::TestProcess,        :type => :controller
+    config.include ::Rails::Controller::Testing::TemplateAssertions, :type => :controller
+    config.include ::Rails::Controller::Testing::Integration,        :type => :controller
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ SORCERY_ORM = :active_record
 # require 'simplecov'
 # SimpleCov.root File.join(File.dirname(__FILE__), '..', 'lib')
 # SimpleCov.start
-
-require 'rspec'
-
 require 'rails/all'
 require 'rspec/rails'
 require 'timecop'


### PR DESCRIPTION
This PR pass all tests and fix deprecation warnings on Rails 5.

In the process, I removed test of rails 4.0.1. https://github.com/Sorcery/sorcery/commit/b69a89bbe0e6ed2aac6a9fc3694ce1bfaf248a71
Because `render plain` did not exist on rails 4.0.1, but It needs on Rails 5. https://github.com/Sorcery/sorcery/commit/4fc164f2e285ca1f85d16497113b8730bedd3041
I can also fix this problem with the way like [this](https://github.com/Sorcery/sorcery/compare/master...kyuden:rails5?expand=1#diff-d0d1d0d5ee17b0aee49ab5b831d7e9a3R66) , but rails 4.0.1 have not been maintained yet. So I removed test of rails 4.0.1.  What do you think?

related: https://github.com/Sorcery/sorcery/issues/20

edit:
I noticed test of rails 4.0.1 don't need to be drop. So, I added a test of rails 5 only.