### PR TITLE
Support Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.1.10
   - 2.2.6
   - 2.3.3
+  - 2.4.0
 
 env:
   global:
@@ -42,6 +43,15 @@ matrix:
 
     - rvm: 2.3.3
       gemfile: gemfiles/active_record-rails40.gemfile
+
+    - rvm: 2.4.0
+      gemfile: gemfiles/active_record-rails40.gemfile
+
+    - rvm: 2.4.0
+      gemfile: gemfiles/active_record-rails41.gemfile
+
+    - rvm: 2.4.0
+      gemfile: gemfiles/active_record-rails42.gemfile
 
     - rvm: jruby
       gemfile: Gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Added null: false to migrations
 * Added support for Rails 5 by @kyuden
 * Added WeChat provider to external submodule.
+* Added support for Ruby 2.4 by @kyuden
 
 ## 0.9.1
 

--- a/lib/sorcery/crypto_providers/aes256.rb
+++ b/lib/sorcery/crypto_providers/aes256.rb
@@ -43,7 +43,7 @@ module Sorcery
 
         def aes
           raise ArgumentError, "#{name} expects a 32 bytes long key. Please use Sorcery::Model::Config.encryption_key to set it." if @key.nil? || @key == ''
-          @aes ||= OpenSSL::Cipher::Cipher.new('AES-256-ECB')
+          @aes ||= OpenSSL::Cipher.new('AES-256-ECB')
         end
       end
     end

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -24,9 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '>= 0.8.0'
   s.add_dependency 'bcrypt', '~> 3.1'
 
-  s.add_development_dependency 'json', '>= 1.7.7'
   s.add_development_dependency 'yard', '~> 0.6.0'
-
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'simplecov', '>= 0.3.8'
   s.add_development_dependency 'rspec-rails', '~> 3.5.0'

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth2', '>= 0.8.0'
   s.add_dependency 'bcrypt', '~> 3.1'
 
-  s.add_development_dependency 'abstract', '>= 1.0.0'
   s.add_development_dependency 'json', '>= 1.7.7'
   s.add_development_dependency 'yard', '~> 0.6.0'
 

--- a/spec/sorcery_crypto_providers_spec.rb
+++ b/spec/sorcery_crypto_providers_spec.rb
@@ -115,7 +115,7 @@ describe 'Crypto Providers wrappers' do
 
   describe Sorcery::CryptoProviders::AES256 do
     before(:all) do
-      aes = OpenSSL::Cipher::Cipher.new('AES-256-ECB')
+      aes = OpenSSL::Cipher.new('AES-256-ECB')
       aes.encrypt
       @key = 'asd234dfs423fddsmndsflktsdf32343'
       aes.key = @key
@@ -137,7 +137,7 @@ describe 'Crypto Providers wrappers' do
     end
 
     it 'can be decrypted' do
-      aes = OpenSSL::Cipher::Cipher.new('AES-256-ECB')
+      aes = OpenSSL::Cipher.new('AES-256-ECB')
       aes.decrypt
       aes.key = @key
       expect(aes.update(@digest.unpack('m').first) + aes.final).to eq 'Noam Ben-Ari'


### PR DESCRIPTION
Ruby 2.4.0 Released. :christmas_tree:
This PR fixed mainly deprecation warnings on Ruby 2.4. 
 - Fix warning of deprecated constant.
 - Test against ruby 2.4.0 on CI.

In addition, I cleaned sorcery.gemspec
 - Drop json gem dependency for development
   - The dependency for json gem is custom for Ruby 1.8. We should use json of a standard library.
 - Drop abstract gem dependency for development 

