### PR TITLE
Resurrect block authentication

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -80,10 +80,12 @@ module Sorcery
       # Takes a username and password,
       # Finds the user by the username and compares the user's password to the one supplied to the method.
       # returns the user if success, nil otherwise.
-      def authenticate(*credentials)
+      def authenticate(*credentials, &block)
         raise ArgumentError, 'at least 2 arguments required' if credentials.size < 2
 
-        return false if credentials[0].blank?
+        if credentials[0].blank?
+          return authentication_response(return_value: false, failure: :invalid_login, &block)
+        end
 
         if @sorcery_config.downcase_username_before_authenticating
           credentials[0].downcase!
@@ -91,13 +93,29 @@ module Sorcery
 
         user = sorcery_adapter.find_by_credentials(credentials)
 
-        if user.respond_to?(:active_for_authentication?)
-          return nil unless user.active_for_authentication?
+        unless user
+          return authentication_response(failure: :invalid_login, &block)
         end
 
         set_encryption_attributes
 
-        user if user && @sorcery_config.before_authenticate.all? { |c| user.send(c) } && user.valid_password?(credentials[1])
+        unless user.valid_password?(credentials[1])
+          return authentication_response(user: user, failure: :invalid_password, &block)
+        end
+
+        if user.respond_to?(:active_for_authentication?) && !user.active_for_authentication?
+          return authentication_response(user: user, failure: :inactive, &block)
+        end
+
+        @sorcery_config.before_authenticate.each do |callback|
+          success, reason = user.send(callback)
+
+          unless success
+            return authentication_response(user: user, failure: reason, &block)
+          end
+        end
+
+        authentication_response(user: user, return_value: user, &block)
       end
 
       # encrypt tokens using current encryption_provider.
@@ -111,6 +129,12 @@ module Sorcery
       end
 
       protected
+
+      def authentication_response(options = {})
+        yield(options[:user], options[:failure]) if block_given?
+
+        options[:return_value]
+      end
 
       def set_encryption_attributes
         @sorcery_config.encryption_provider.stretches = @sorcery_config.stretches if @sorcery_config.encryption_provider.respond_to?(:stretches) && @sorcery_config.stretches

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -55,10 +55,13 @@ module Sorcery
         module ClassMethods
           # Find user by token, also checks for expiration.
           # Returns the user if token found and is valid.
-          def load_from_reset_password_token(token)
-            token_attr_name = @sorcery_config.reset_password_token_attribute_name
-            token_expiration_date_attr = @sorcery_config.reset_password_token_expires_at_attribute_name
-            load_from_token(token, token_attr_name, token_expiration_date_attr)
+          def load_from_reset_password_token(token, &block)
+            load_from_token(
+              token,
+              @sorcery_config.reset_password_token_attribute_name,
+              @sorcery_config.reset_password_token_expires_at_attribute_name,
+              &block
+            )
           end
 
           protected

--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -59,10 +59,13 @@ module Sorcery
         module ClassMethods
           # Find user by token, also checks for expiration.
           # Returns the user if token found and is valid.
-          def load_from_activation_token(token)
-            token_attr_name = @sorcery_config.activation_token_attribute_name
-            token_expiration_date_attr = @sorcery_config.activation_token_expires_at_attribute_name
-            load_from_token(token, token_attr_name, token_expiration_date_attr)
+          def load_from_activation_token(token, &block)
+            load_from_token(
+              token,
+              @sorcery_config.activation_token_attribute_name,
+              @sorcery_config.activation_token_expires_at_attribute_name,
+              &block
+            )
           end
 
           protected
@@ -128,7 +131,14 @@ module Sorcery
 
           def prevent_non_active_login
             config = sorcery_config
-            config.prevent_non_active_users_to_login ? send(config.activation_state_attribute_name) == 'active' : true
+
+            if config.prevent_non_active_login
+              unless send(config.activation_state_attribute_name) == 'active'
+                return false, :inactive
+              end
+            end
+
+            true
           end
         end
       end

--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -132,7 +132,7 @@ module Sorcery
           def prevent_non_active_login
             config = sorcery_config
 
-            if config.prevent_non_active_login
+            if config.prevent_non_active_users_to_login
               unless send(config.activation_state_attribute_name) == 'active'
                 return false, :inactive
               end

--- a/lib/sorcery/model/temporary_token.rb
+++ b/lib/sorcery/model/temporary_token.rb
@@ -27,7 +27,7 @@ module Sorcery
             return token_response(user: user, failure: :token_expired, &block)
           end
 
-          token_response(user: user, return_value: :user, &block)
+          token_response(user: user, return_value: user, &block)
         end
 
         protected

--- a/lib/sorcery/model/temporary_token.rb
+++ b/lib/sorcery/model/temporary_token.rb
@@ -16,13 +16,34 @@ module Sorcery
       end
 
       module ClassMethods
-        def load_from_token(token, token_attr_name, token_expiration_date_attr)
-          return nil if token.blank?
+        def load_from_token(token, token_attr_name, token_expiration_date_attr = nil, &block)
+          return token_response(failure: :invalid_token, &block) if token.blank?
+
           user = sorcery_adapter.find_by_token(token_attr_name, token)
-          if !user.blank? && !user.send(token_expiration_date_attr).nil?
-            return Time.now.in_time_zone < user.send(token_expiration_date_attr) ? user : nil
+
+          return token_response(failure: :user_not_found, &block) unless user
+
+          unless check_expiration_date(user, token_expiration_date_attr)
+            return token_response(user: user, failure: :token_expired, &block)
           end
-          user
+
+          token_response(user: user, return_value: :user, &block)
+        end
+
+        protected
+
+        def check_expiration_date(user, token_expiration_date_attr)
+          return true unless token_expiration_date_attr
+
+          expires_at = user.send(token_expiration_date_attr)
+
+          !expires_at || (Time.now.in_time_zone < expires_at)
+        end
+
+        def token_response(options = {})
+          yield(options[:user], options[:failure]) if block_given?
+
+          options[:return_value]
         end
       end
     end

--- a/spec/controllers/controller_brute_force_protection_spec.rb
+++ b/spec/controllers/controller_brute_force_protection_spec.rb
@@ -20,7 +20,7 @@ describe SorceryController, type: :controller do
     end
 
     it 'counts login retries' do
-      allow(User).to receive(:authenticate)
+      allow(User).to receive(:authenticate) { |&block| block.call(nil, :other) }
       allow(User.sorcery_adapter).to receive(:find_by_credentials).with(['bla@bla.com', 'blabla']).and_return(user)
 
       expect(user).to receive(:register_failed_login!).exactly(3).times
@@ -32,7 +32,7 @@ describe SorceryController, type: :controller do
       # dirty hack for rails 4
       allow(@controller).to receive(:register_last_activity_time_to_db)
 
-      allow(User).to receive(:authenticate).and_return(user)
+      allow(User).to receive(:authenticate) { |&block| block.call(user, nil) }
       expect(user).to receive_message_chain(:sorcery_adapter, :update_attribute).with(:failed_logins_count, 0)
 
       get :test_login, params: { email: 'bla@bla.com', password: 'secret' }

--- a/spec/controllers/controller_remember_me_spec.rb
+++ b/spec/controllers/controller_remember_me_spec.rb
@@ -22,7 +22,7 @@ describe SorceryController, type: :controller do
     end
 
     it 'sets cookie on remember_me!' do
-      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
+      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
       expect(user).to receive(:remember_me!)
 
       post :test_login_with_remember, params: { email: 'bla@bla.com', password: 'secret' }
@@ -45,7 +45,7 @@ describe SorceryController, type: :controller do
     end
 
     it 'login(email,password,remember_me) logs user in and remembers' do
-      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret', '1').and_return(user)
+      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret', '1') { |&block| block.call(user, nil) }
       expect(user).to receive(:remember_me!)
       expect(user).to receive(:remember_me_token).and_return('abracadabra').twice
 

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -39,7 +39,7 @@ describe SorceryController, type: :controller do
     it 'works if the session is stored as a string or a Time' do
       session[:login_time] = Time.now.to_s
       # TODO: ???
-      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
+      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
 
       get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
 
@@ -50,7 +50,7 @@ describe SorceryController, type: :controller do
     context "with 'session_timeout_from_last_action'" do
       it 'does not logout if there was activity' do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
-        expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
+        expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
 
         get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
         Timecop.travel(Time.now.in_time_zone + 0.3)

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -52,7 +52,7 @@ describe SorceryController, type: :controller do
     describe '#login' do
       context 'when succeeds' do
         before do
-          expect(User).to receive(:authenticate).with('bla@bla.com', 'secret').and_return(user)
+          expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
           get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
         end
 

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -146,6 +146,31 @@ shared_examples_for 'rails_3_core_model' do
           expect(User.authenticate(user.email, 'secret')).to be_nil
         end
       end
+
+      context 'in block mode' do
+        it 'yields the user if credentials are good' do
+          User.authenticate(user.email, 'secret') do |user2, failure|
+            expect(user2).to eq user
+            expect(failure).to be_nil
+          end
+        end
+
+        it 'yields the user and proper error if credentials are bad' do
+          User.authenticate(user.email, 'wrong!') do |user2, failure|
+            expect(user2).to eq user
+            expect(failure).to eq :invalid_password
+          end
+        end
+
+        it 'yields the proper error if no user exists' do
+          [nil, '', 'not@a.user'].each do |email|
+            User.authenticate(email, 'wrong!') do |user2, failure|
+              expect(user2).to be_nil
+              expect(failure).to eq :invalid_login
+            end
+          end
+        end
+      end
     end
 
     specify { expect(User).to respond_to(:encrypt) }


### PR DESCRIPTION
This was never merged into the old repo, but I still think it's a worthwhile change.

https://github.com/NoamB/sorcery/pull/704

These changes allow a website to tell the difference between a wrong password, a locked account, and an inactive account, so that the user can be sent to a "resend activation" or "unlock account" page when necessary.