### PR TITLE
Add github scope option to initializer.rb

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -115,6 +115,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.github.secret = ""
   # config.github.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=github"
   # config.github.user_info_mapping = {:email => "name"}
+  # config.github.scope = ""
   #
   # config.paypal.key = ""
   # config.paypal.secret = ""


### PR DESCRIPTION
As I found the undocumented option which is about Github's scope with external module in Github OAuth. I think it is better if this pull request is accept, because it takes time to find the option out if someone who uses Github OAuth with external module and want to manage the Github's scope.
I don't want to change original behavior when ` comment out ` of added option is remove, so default value is blank. (blank scope is called [ ` no scope ` ](https://developer.github.com/v3/oauth/#scopes).)

refs: #48 