### PR TITLE
Allow changing facebook parser and change default parser to json

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -109,8 +109,8 @@ Rails.application.config.sorcery.configure do |config|
   # config.facebook.user_info_mapping = {:email => "name"}
   # config.facebook.access_permissions = ["email", "publish_actions"]
   # config.facebook.display = "page"
-  # config.facebook.api_version = "v2.2"
-  # config.facebook.parse = :query
+  # config.facebook.api_version = "v2.3"
+  # config.facebook.parse = :json
   #
   # config.github.key = ""
   # config.github.secret = ""

--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -110,6 +110,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.facebook.access_permissions = ["email", "publish_actions"]
   # config.facebook.display = "page"
   # config.facebook.api_version = "v2.2"
+  # config.facebook.parse = :query
   #
   # config.github.key = ""
   # config.github.secret = ""

--- a/lib/sorcery/providers/facebook.rb
+++ b/lib/sorcery/providers/facebook.rb
@@ -9,9 +9,9 @@ module Sorcery
     class Facebook < Base
       include Protocols::Oauth2
 
-      attr_reader   :mode, :param_name, :parse
+      attr_reader   :mode, :param_name
       attr_accessor :access_permissions, :display, :scope, :token_url,
-                    :user_info_path, :auth_path, :api_version
+                    :user_info_path, :auth_path, :api_version, :parse
 
       def initialize
         super

--- a/lib/sorcery/providers/facebook.rb
+++ b/lib/sorcery/providers/facebook.rb
@@ -24,7 +24,7 @@ module Sorcery
         @token_url      = 'oauth/access_token'
         @auth_path      = 'dialog/oauth'
         @mode           = :query
-        @parse          = :query
+        @parse          = :json
         @param_name     = 'access_token'
       end
 


### PR DESCRIPTION
With Facebook deprecating version 2.2 of the Graph API, they now only return json access tokens.

See https://developers.facebook.com/docs/apps/changelog

[Oauth Access Token] Format - The response format of https://www.facebook.com/v2.3/oauth/access_token returned when you exchange a code for an access_token now return valid JSON instead of being URL encoded. The new format of this response is {"access_token": {TOKEN}, "token_type":{TYPE}, "expires_in":{TIME}}. We made this update to be compliant with section 5.1 of RFC 6749.