### PR TITLE
Change default value of config.github.user_info_mapping

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -114,7 +114,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.github.key = ""
   # config.github.secret = ""
   # config.github.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=github"
-  # config.github.user_info_mapping = {:email => "name"}
+  # config.github.user_info_mapping = {:email => "login"}
   # config.github.scope = ""
   #
   # config.paypal.key = ""


### PR DESCRIPTION
I'd like to change the default value of `config.github.user_info_mapping` because the value of name is duplicatable on GitHub and the default key (`email`) cannot duplicate. What do you think about this?