### PR TITLE
Fix issue #40

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -357,6 +357,11 @@ Rails.application.config.sorcery.configure do |config|
     # Default: `5 * 60`
     #
     # user.reset_password_time_between_emails =
+    
+    # access counter to a reset password page attribute name
+    # Default: `:access_count_to_reset_password_page`
+    #
+    # user.reset_password_page_access_count_attribute_name =
 
     # -- brute_force_protection --
     # Failed logins attribute name.

--- a/lib/generators/sorcery/templates/migration/reset_password.rb
+++ b/lib/generators/sorcery/templates/migration/reset_password.rb
@@ -3,6 +3,7 @@ class SorceryResetPassword < <%= migration_class_name %>
     add_column :<%= model_class_name.tableize %>, :reset_password_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :reset_password_token_expires_at, :datetime, :default => nil
     add_column :<%= model_class_name.tableize %>, :reset_password_email_sent_at, :datetime, :default => nil
+    add_column :<%= model_class_name.tableize %>, :access_count_to_reset_password_page, :integer, :default => 0
 
     add_index :<%= model_class_name.tableize %>, :reset_password_token
   end

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -109,8 +109,8 @@ module Sorcery
           end
           
           # Increment access_count_to_reset_password_page attribute.
-          # For example, access_count_to_reset_password_page attribute is over 1, which means
-          # some one doesn't have a right to access.
+          # For example, access_count_to_reset_password_page attribute is over 1, which
+          # means the user doesn't have a right to access.
           def increment_password_reset_page_access_counter
             accessed_count = send(sorcery_config.reset_password_page_access_count_attribute_name)
             send(:"#{sorcery_config.reset_password_page_access_count_attribute_name}=", accessed_count+1)

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -112,9 +112,7 @@ module Sorcery
           # For example, access_count_to_reset_password_page attribute is over 1, which
           # means the user doesn't have a right to access.
           def increment_password_reset_page_access_counter
-            accessed_count = send(sorcery_config.reset_password_page_access_count_attribute_name)
-            send(:"#{sorcery_config.reset_password_page_access_count_attribute_name}=", accessed_count+1)
-            sorcery_adapter.save
+            sorcery_adapter.increment(self.sorcery_config.reset_password_page_access_count_attribute_name)
           end
           
           # Reset access_count_to_reset_password_page attribute into 0.

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -16,6 +16,8 @@ module Sorcery
             attr_accessor :reset_password_token_attribute_name
             # Expires at attribute name.
             attr_accessor :reset_password_token_expires_at_attribute_name
+            # Counter access to reset password page
+            attr_accessor :reset_password_page_access_count_attribute_name
             # When was email sent, used for hammering protection.
             attr_accessor :reset_password_email_sent_at_attribute_name
             # Mailer class (needed)
@@ -34,6 +36,8 @@ module Sorcery
           base.sorcery_config.instance_eval do
             @defaults.merge!(:@reset_password_token_attribute_name            => :reset_password_token,
                              :@reset_password_token_expires_at_attribute_name => :reset_password_token_expires_at,
+                             :@reset_password_page_access_count_attribute_name =>
+                                 :access_count_to_reset_password_page,
                              :@reset_password_email_sent_at_attribute_name    => :reset_password_email_sent_at,
                              :@reset_password_mailer                          => nil,
                              :@reset_password_mailer_disabled                 => false,
@@ -102,6 +106,22 @@ module Sorcery
               mail = send_reset_password_email! unless config.reset_password_mailer_disabled
             end
             mail
+          end
+          
+          # Increment access_count_to_reset_password_page attribute.
+          # For example, access_count_to_reset_password_page attribute is over 1, which means
+          # some one doesn't have a right to access.
+          def increment_password_reset_page_access_counter
+            accessed_count = send(sorcery_config.reset_password_page_access_count_attribute_name)
+            send(:"#{sorcery_config.reset_password_page_access_count_attribute_name}=", accessed_count+1)
+            sorcery_adapter.save
+          end
+          
+          # Reset access_count_to_reset_password_page attribute into 0.
+          # This is expected to be used after sending an instruction email.
+          def reset_password_reset_page_access_counter
+            send(:"#{sorcery_config.reset_password_page_access_count_attribute_name}=", 0)
+            sorcery_adapter.save
           end
 
           # Clears token and tries to update the new password for the user.

--- a/spec/rails_app/db/migrate/reset_password/20101224223622_add_reset_password_to_users.rb
+++ b/spec/rails_app/db/migrate/reset_password/20101224223622_add_reset_password_to_users.rb
@@ -3,11 +3,13 @@ class AddResetPasswordToUsers < ActiveRecord::CompatibleLegacyMigration.migratio
     add_column :users, :reset_password_token, :string, default: nil
     add_column :users, :reset_password_token_expires_at, :datetime, default: nil
     add_column :users, :reset_password_email_sent_at, :datetime, default: nil
+    add_column :users, :access_count_to_reset_password_page, :integer, default: 0
   end
 
   def self.down
     remove_column :users, :reset_password_email_sent_at
     remove_column :users, :reset_password_token_expires_at
     remove_column :users, :reset_password_token
+    remove_column :users, :access_count_to_reset_password_page
   end
 end

--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -214,6 +214,22 @@ shared_examples_for 'rails_3_reset_password_model' do
       expect(user.reset_password_token).not_to eq old_password_code
     end
 
+    describe '#increment_password_reset_page_access_counter' do
+      it 'increments reset_password_page_access_count_attribute_name' do
+        expected_count = user.access_count_to_reset_password_page + 1
+        user.increment_password_reset_page_access_counter
+        expect(user.access_count_to_reset_password_page).to eq expected_count
+      end
+    end
+
+    describe '#reset_password_reset_page_access_counter' do
+      it 'reset reset_password_page_access_count_attribute_name into 0' do
+        user.update(access_count_to_reset_password_page: 10)
+        user.reset_password_reset_page_access_counter
+        expect(user.access_count_to_reset_password_page).to eq 0
+      end
+    end
+
     context 'mailer is enabled' do
       it 'sends an email on reset' do
         old_size = ActionMailer::Base.deliveries.size


### PR DESCRIPTION
Fix [Password reset token leak via HTTP referer](https://github.com/Sorcery/sorcery/issues/40).
This change requires to update [the documentation](https://github.com/Sorcery/sorcery/wiki/Reset-password) accordingly, and I will explain how to fix it in implementation and the documentation (written below).

## Implementation
I follow the step of the first direction mentioned in [Is Your Site Leaking Password Reset Links?](https://robots.thoughtbot.com/is-your-site-leaking-password-reset-links#testing-your-site): 
>Update the passwords#edit controller action so it immediately invalidates the password reset token in the request and generates a new one that is used in the form action. The Referer will still contain the original password reset token, but the token is no longer valid.

* Add access_count_to_reset_password_page attribute to user model, responsible for the count how many times the password reset page is accessed.
In `lib/sorcery/model/submodules/reset_password.rb`, 
* Add `#increment_password_reset_page_access_counter`, which increments access_count_to_reset_password_page attribute.
* Add `#reset_password_reset_page_access_counter`. This resets access_count_to_reset_password_page attribute to 0

I will explain how these changes affect the password reset feature in a rails application below.

## Documentation
The wiki is expected to update as follows only `PasswordResetsController#create` and `PasswordResetsController#edit`:
```
class PasswordResetsController < ApplicationController
  skip_before_filter :require_login
  
  def create
    @user = User.find_by_email(params[:email])
    
    #### Difference Start#####
    # Sends an email to the user with instructions on how to reset their password (a url with a random token)
    # Don't forget to reset password_reset_page_access_counter
    # For security reset password page can be accessed only once.
    if @user
      @user.deliver_reset_password_instructions!
      @user.reset_password_reset_page_access_counter
    end
    #### Difference End #####
    
    # Tell the user instructions have been sent whether or not email was found.
    # This is to not leak information to attackers about which emails exist in the system.
    redirect_to(root_path, :notice => 'Instructions have been sent to your email.')
  end
  
  # This is the reset password form.
  def edit
    @token = params[:id]
    @user = User.load_from_reset_password_token(params[:id])
    
    if @user.blank?
      not_authenticated
      return
    end
    
    #### Difference Start #####
    # Increment password reset page access counter
    @user.increment_password_reset_page_access_counter

    #  password reset page can't be accessed more than twice
    if @user.access_count_to_reset_password_page > 1
      # It's nice to override #not_authenticated to show a message of the reason not authenticated.
      not_authenticated
      return
    end
    #### Difference End #####
  end
end
```

## Testing
### Sorcery
All specs are green.
### Documentation
Test the steps mentioned in [Is Your Site Leaking Password Reset Links?](https://robots.thoughtbot.com/is-your-site-leaking-password-reset-links#testing-your-site), confirming the second access is invalid.
>1. Request a password reset and click the link that is emailed to you.
>2. Copy the URL from the resulting page.
>3. Open a private browser window or a different web browser and paste the copied URL.
>If a working password reset form is rendered then you have proven that without any mitigating steps, any Referer generated by this page would contain a working password reset URL.

