### PR TITLE
Fixed : “NameError: constant Object::User not defined” error message when you run the single spec file

### DIFF
--- a/lib/sorcery/test_helpers/internal.rb
+++ b/lib/sorcery/test_helpers/internal.rb
@@ -67,7 +67,7 @@ module Sorcery
       # reload user class between specs
       # so it will be possible to test the different submodules in isolation
       def reload_user_class
-        Object.send(:remove_const, 'User')
+        User && Object.send(:remove_const, 'User')
         load 'user.rb'
         if User.respond_to?(:reset_column_information)
           User.reset_column_information


### PR DESCRIPTION
## Symptoms

I ran the single file test

`rspec spec/controllers/controller_spec.rb`

And got the error below:

```
NameError:
  constant Object::User not defined

# ./lib/sorcery/test_helpers/internal.rb:70:in `remove_const'
# ./lib/sorcery/test_helpers/internal.rb:70:in `reload_user_class'
# ./lib/sorcery/test_helpers/internal/rails.rb:14:in `sorcery_reload!'
# ./spec/controllers/controller_http_basic_auth_spec.rb:8:in `block (3 levels) in <top (required)>'
```        

## Cause

If you call `remove_const` before the first constant reference, a name error occurs.
Because constant autoloading in Rails is implemented with Module#const_missing.

## Resolution

I Changed  `reload_user_class` to refer ‘User’ constant before reload.