### PR TITLE
Add if statement for api mode

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -45,7 +45,7 @@ module Sorcery
           old_session.each_pair do |k, v|
             session[k.to_sym] = v
           end
-          form_authenticity_token
+          form_authenticity_token if self.respond_to?(:form_authenticity_token)
 
           auto_login(user)
           after_login!(user, credentials)


### PR DESCRIPTION
Hi. I added 1 if statement for API mode because `form_authenticity_token` is defined at  `action_view`. So it couldn't be used in API mode.

```
[3] pry(#<Api::V1::UsersController>)> login(user_params[:email], user_params[:password])
  User Load (1.3ms)  SELECT  "users".* FROM "users" WHERE "users"."email" = 'sample@ggg.com' ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
NameError: undefined local variable or method `form_authenticity_token' for #<Api::V1::UsersController:0x007f9c5c089bc0>
from /Users/asmsuechan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/sorcery-0.10.3/lib/sorcery/controller.rb:40:in `login'
```