### PR TITLE
Delete unsupported ruby versions from CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 rvm:
   - jruby
-  - 2.0.0
-  - 2.1.10
   - 2.2.6
   - 2.3.3
   - 2.4.0
@@ -29,15 +27,6 @@ matrix:
     - rvm: jruby
 
   exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/active_record-rails42.gemfile
-
-    - rvm: 2.0.0
-      gemfile: Gemfile
-
-    - rvm: 2.1.10
-      gemfile: Gemfile
-
     - rvm: 2.2.6
       gemfile: gemfiles/active_record-rails40.gemfile
 


### PR DESCRIPTION
Travis CI tests ruby 2.0 and 2.1, which forces to use hash rocket. I think sorcery needs the code guideline by introducing Rubocop in the future, but this old way notation prevents it.

It's also natural to make users doubt whether this product is still maintained by supporting too old ruby versions. Of course I know sorcery is actively maintained, and it's not good.

I confirm tests are all green.

Thanks for reviewing.