### PR TITLE
Set user.stretches to 1 in test env by default

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -232,9 +232,9 @@ Rails.application.config.sorcery.configure do |config|
     # user.salt_attribute_name =
 
     # how many times to apply encryption to the password.
-    # Default: `nil`
+    # Default: 1 in test env, `nil` otherwise
     #
-    # user.stretches =
+    user.stretches = 1 if Rails.env.test?
 
     # encryption key used to encrypt reversible encryptions such as AES256.
     # WARNING: If used for users' passwords, changing this key will leave passwords undecryptable!


### PR DESCRIPTION
Most users use BCrypt and don't change defaults, which means that the default value would be 10. That makes tests run slowly.

Setting the number of stretches in test env to 1 can decrease the test suite up to 2x times (although BCrypt minimal cost is 4, we can use 1 for SHA algorithms).