### PR TITLE
add new ArgumentError for not defined user_class in config

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -156,7 +156,7 @@ module Sorcery
       def user_class
         @user_class ||= Config.user_class.to_s.constantize
       rescue NameError
-        raise ArgumentError, 'You define wrong user_class or forgot to define it in intitializer file (config.user_class = \'User\').'
+        raise ArgumentError, 'You have incorrectly defined user_class or have forgotten to define it in intitializer file (config.user_class = \'User\').'
       end
     end
   end

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -155,6 +155,8 @@ module Sorcery
 
       def user_class
         @user_class ||= Config.user_class.to_s.constantize
+      rescue NameError
+        raise ArgumentError, 'You define wrong user_class or forgot to define it in intitializer file (config.user_class = \'User\').'
       end
     end
   end


### PR DESCRIPTION
I add these error, because earlier, if we forgot to define user_class (f.e. not add sorcery.rb to initializers) we got just NameError, which not easy to google for newbie developers. 