### PR TITLE
adding 'include_email' parameter

### DIFF
--- a/lib/sorcery/providers/twitter.rb
+++ b/lib/sorcery/providers/twitter.rb
@@ -15,7 +15,7 @@ module Sorcery
         super
 
         @site           = 'https://api.twitter.com'
-        @user_info_path = '/1.1/account/verify_credentials.json'
+        @user_info_path = '/1.1/account/verify_credentials.json?include_email=true'
       end
 
       # Override included get_consumer method to provide authorize_path


### PR DESCRIPTION
With this parameter user can get `email address` from Twitter REST API, it will be returned in the user objects as a string. If the user does not have an email address on their account, or if the email address is not verified, null will be returned.