### PR TITLE
Make `#update_attributes` behavior identical to `#update`

### DIFF
--- a/lib/sorcery/adapters/active_record_adapter.rb
+++ b/lib/sorcery/adapters/active_record_adapter.rb
@@ -6,7 +6,8 @@ module Sorcery
           @model.send(:"#{name}=", value)
         end
         primary_key = @model.class.primary_key
-        @model.class.where(:"#{primary_key}" => @model.send(:"#{primary_key}")).update_all(attrs)
+        updated_count = @model.class.where(:"#{primary_key}" => @model.send(:"#{primary_key}")).update_all(attrs)
+        updated_count == 1
       end
 
       def save(options = {})


### PR DESCRIPTION
This is the PR for the [issue#87](https://github.com/Sorcery/sorcery/issues/87)
See there for details.

Another choice of implemention is like this:

```
@model.class.find_by(:"#{primary_key}" =>
@model.send(:"#{primary_key}")).update(attrs)
```

but for some reasons I don't adopt it.
First it makes 2 queries instead of one.
Secondly it has potential risk to race conditions.