### PR TITLE
fix magic login migration.

### DIFF
--- a/lib/generators/sorcery/templates/migration/magic_login.rb
+++ b/lib/generators/sorcery/templates/migration/magic_login.rb
@@ -1,4 +1,4 @@
-class SorceryMagicLogin < ActiveRecord::Migration
+class SorceryMagicLogin < <%= migration_class_name %>
   def change
     add_column :<%= model_class_name.tableize %>, :magic_login_token, :string, :default => nil
     add_column :<%= model_class_name.tableize %>, :magic_login_token_expires_at, :datetime, :default => nil


### PR DESCRIPTION
I use rails 5.1 and sorcery(github head).

so, I Migrated with this command: 
```
$ bundle exec rails g sorcery:install core magic_login --model Authentication
$ bundle exec rails db:migration
```

At that time, a migration error occurred using "magic login" module.
The problem was this part, and it succeeded when corrected.