### PR TITLE
Respect SessionTimeout on login via RememberMe

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -153,6 +153,10 @@ module Sorcery
         Config.after_logout.each { |c| send(c, user) }
       end
 
+      def after_remember_me!(user)
+        Config.after_remember_me.each { |c| send(c, user) }
+      end
+
       def user_class
         @user_class ||= Config.user_class.to_s.constantize
       rescue NameError

--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -18,6 +18,7 @@ module Sorcery
         attr_accessor :after_failed_login
         attr_accessor :before_logout
         attr_accessor :after_logout
+        attr_accessor :after_remember_me
 
         def init!
           @defaults = {
@@ -29,6 +30,7 @@ module Sorcery
             :@after_failed_login                   => [],
             :@before_logout                        => [],
             :@after_logout                         => [],
+            :@after_remember_me                    => [],
             :@save_return_to_url                   => true,
             :@cookie_domain                        => nil
           }

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -65,6 +65,7 @@ module Sorcery
             if user && user.has_remember_me_token?
               set_remember_me_cookie!(user)
               session[:user_id] = user.id.to_s
+              after_remember_me!(user)
               @current_user = user
             else
               @current_user = false

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -21,6 +21,7 @@ module Sorcery
             merge_session_timeout_defaults!
           end
           Config.after_login << :register_login_time
+          Config.after_remember_me << :register_login_time
           base.prepend_before_action :validate_session
         end
 
@@ -29,7 +30,7 @@ module Sorcery
 
           # Registers last login to be used as the timeout starting point.
           # Runs as a hook after a successful login.
-          def register_login_time(_user, _credentials)
+          def register_login_time(_user, _credentials = nil)
             session[:login_time] = session[:last_action_time] = Time.now.in_time_zone
           end
 

--- a/spec/controllers/controller_remember_me_spec.rb
+++ b/spec/controllers/controller_remember_me_spec.rb
@@ -80,6 +80,8 @@ describe SorceryController, type: :controller do
 
       expect(User.sorcery_adapter).to receive(:find_by_remember_me_token).with('token').and_return(user)
 
+      expect(subject).to receive(:after_remember_me!).with(user)
+
       get :test_login_from_cookie
 
       expect(assigns[:current_user]).to eq user

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -75,5 +75,11 @@ describe SorceryController, type: :controller do
         expect(response).to be_a_redirect
       end
     end
+
+    it "registers login time on remember_me callback" do
+      expect(subject).to receive(:register_login_time).with(user)
+
+      subject.send(:after_remember_me!, user)
+    end
   end
 end


### PR DESCRIPTION
Before this, an unlimited session was created on login via the remember me cookie, even though the SessionTimeout module is active.

I introduced a new callback (after_remember_me) to allow updating the session timeout on login from cookie without tight coupling both submodules.

It seems like all callbacks / interactions between the submodules are not tested, so I'm not sure if I should test here.. So I just added expectations for calling the specific (callback) methods. 