### PR TITLE
Add an opt in invalidate_active_sessions!  method to session timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ User.load_from_reset_password_token(token)
 @user.change_password!(new_password)
 ```
 
+### Session Timeout
+
+```ruby
+invalidate_active_sessions! #Invalidate all sessions with a login_time or last_action_time before the current time. Must Opt-in
+```
+
 ### User Activation
 
 ```ruby
@@ -184,6 +190,7 @@ Inside the initializer, the comments will tell you what each setting does.
 
 - Configurable session timeout
 - Optionally session timeout will be calculated from last user action
+- Optionally enable a method to clear all active sessions, expects an `invalidate_sessions_before` datetime attribute.
 
 **Brute Force Protection** (see [lib/sorcery/model/submodules/brute_force_protection.rb](https://github.com/Sorcery/sorcery/blob/master/lib/sorcery/model/submodules/brute_force_protection.rb)):
 

--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -46,6 +46,11 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.session_timeout_from_last_action =
 
+  # Invalidate active sessions Requires an `invalidate_sessions_before` timestamp column
+  # Default: `false`
+  #
+  # config.session_timeout_invalidate_active_sessions_enabled =
+
   # -- http_basic_auth --
   # What realm to display for which controller name. For example {"My App" => "Application"}
   # Default: `{"application" => "Application"}`

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -12,10 +12,13 @@ module Sorcery
               attr_accessor :session_timeout
               # use the last action as the beginning of session timeout.
               attr_accessor :session_timeout_from_last_action
+              # allow users to invalidate active sessions
+              attr_accessor :session_timeout_invalidate_active_sessions_enabled
 
               def merge_session_timeout_defaults!
-                @defaults.merge!(:@session_timeout                      => 3600, # 1.hour
-                                 :@session_timeout_from_last_action     => false)
+                @defaults.merge!(:@session_timeout                                    => 3600, # 1.hour
+                                 :@session_timeout_from_last_action                   => false,
+                                 :@session_timeout_invalidate_active_sessions_enabled => false)
               end
             end
             merge_session_timeout_defaults!
@@ -37,7 +40,7 @@ module Sorcery
           # To be used as a before_action, before require_login
           def validate_session
             session_to_use = Config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
-            if session_to_use && sorcery_session_expired?(session_to_use.to_time)
+            if (session_to_use && sorcery_session_expired?(session_to_use.to_time)) || sorcery_session_invalidated?
               reset_sorcery_session
               remove_instance_variable :@current_user if defined? @current_user
             else
@@ -47,6 +50,21 @@ module Sorcery
 
           def sorcery_session_expired?(time)
             Time.now.in_time_zone - time > Config.session_timeout
+          end
+
+          # Use login time if present, otherwise use last action time.
+          def sorcery_session_invalidated?
+            return false unless Config.session_timeout_invalidate_active_sessions_enabled
+            return false unless current_user.present? && current_user.try(:invalidate_sessions_before).present?
+            time = session[:login_time] || session[:last_action_time]
+            time < current_user.invalidate_sessions_before
+          end
+
+          def invalidate_active_sessions!
+            return unless Config.session_timeout_invalidate_active_sessions_enabled
+            return unless current_user.present?
+            current_user.send(:invalidate_sessions_before=, Time.now.in_time_zone)
+            current_user.save
           end
         end
       end

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -28,6 +28,13 @@ module Sorcery
         end
 
         module InstanceMethods
+          def invalidate_active_sessions!
+            return unless Config.session_timeout_invalidate_active_sessions_enabled
+            return unless current_user.present?
+            current_user.send(:invalidate_sessions_before=, Time.now.in_time_zone)
+            current_user.save
+          end
+
           protected
 
           # Registers last login to be used as the timeout starting point.
@@ -58,13 +65,6 @@ module Sorcery
             return false unless current_user.present? && current_user.try(:invalidate_sessions_before).present?
             time = session[:login_time] || session[:last_action_time]
             time < current_user.invalidate_sessions_before
-          end
-
-          def invalidate_active_sessions!
-            return unless Config.session_timeout_invalidate_active_sessions_enabled
-            return unless current_user.present?
-            current_user.send(:invalidate_sessions_before=, Time.now.in_time_zone)
-            current_user.save
           end
         end
       end

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -63,7 +63,7 @@ module Sorcery
           def sorcery_session_invalidated?
             return false unless Config.session_timeout_invalidate_active_sessions_enabled
             return false unless current_user.present? && current_user.try(:invalidate_sessions_before).present?
-            time = session[:login_time] || session[:last_action_time]
+            time = session[:login_time] || session[:last_action_time] || Time.now.in_time_zone
             time < current_user.invalidate_sessions_before
           end
         end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -52,6 +52,11 @@ class SorceryController < ActionController::Base
     head :ok
   end
 
+  def test_invalidate_active_session
+    invalidate_active_sessions!
+    head :ok
+  end
+
   def test_login_with_remember
     @user = login(params[:email], params[:password])
     remember_me!

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -12,6 +12,7 @@ AppRoot::Application.routes.draw do
     get :test_login_from
     get :test_logout_with_remember
     get :test_logout_with_force_forget_me
+    get :test_invalidate_active_session
     get :test_should_be_logged_in
     get :test_create_from_provider
     get :test_add_second_provider

--- a/spec/rails_app/db/migrate/invalidate_active_sessions/20180221093235_add_invalidate_active_sessions_before_to_users.rb
+++ b/spec/rails_app/db/migrate/invalidate_active_sessions/20180221093235_add_invalidate_active_sessions_before_to_users.rb
@@ -1,0 +1,9 @@
+class AddInvalidateSessionsBeforeToUsers < ActiveRecord::CompatibleLegacyMigration.migration_class
+  def self.up
+    add_column :users, :invalidate_sessions_before, :datetime, default: nil
+  end
+
+  def self.down
+    remove_column :users, :invalidate_sessions_before
+  end
+end


### PR DESCRIPTION
Add a configurable `invalid_active_sessions!` method to the session_timeouts module. Configurable, but expects an `invalidate_sessions_before` timestamp column on user. Does not invalidate the session if `invalidate_sessions_before` is not set meaning that if it is deployed it won't log out currently logged in users.

Update the gem version if necessary. Because this is opt in, it should not be a breaking change.

@arnvald