### PR TITLE
Fix: reset session and store unsorcery sessions

### DIFF
--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -182,7 +182,7 @@ describe SorceryController, type: :controller do
     end
 
     describe '#reset_session' do
-      let(:session_key) { SorceryController.sorcery_session_keys.sample }
+      let(:session_key) { SorceryController.sorcery_session_keys.reject {|key| key == :user_id}.sample }
 
       context 'when works login' do
         before do

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -180,5 +180,42 @@ describe SorceryController, type: :controller do
 
       expect(assigns[:result]).to eq user
     end
+
+    describe '#reset_session' do
+      let(:session_key) { SorceryController.sorcery_session_keys.sample }
+
+      context 'when works login' do
+        before do
+          session[:store_session_key] = :store
+          session[session_key.to_sym] = session_key.to_s
+          session[:return_to_url]     = 'http://reset_session.spec'
+
+          expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
+          get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+        end
+
+        it 'reset session user_id' do
+          expect(session[:user_id]).to eq user.id.to_s
+        end
+
+        it 'store session store_session_key' do
+          expect(session[:store_session_key]).to eq :store
+        end
+
+        it 'reset sorcery_sessions' do
+          expect(session[session_key.to_sym]).to be_nil
+        end
+      end
+    end
+
+    it 'sorcery_session_keys return session keys used in sorcery' do
+      sorcery_session_keys = [
+        :user_id, :http_authentication_used, :login_time,
+        :request_token, :request_token_secret, :last_action_time,
+        :return_to_url, :incomplete_user
+      ]
+
+      expect(SorceryController.sorcery_session_keys).to match_array(sorcery_session_keys)
+    end
   end
 end

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -182,7 +182,7 @@ describe SorceryController, type: :controller do
     end
 
     describe '#reset_session' do
-      let(:session_key) { SorceryController.sorcery_session_keys.reject {|key| key == :user_id}.sample }
+      let(:session_key) { SorceryController.sorcery_session_keys.reject { |key| key == :user_id }.sample }
 
       context 'when works login' do
         before do


### PR DESCRIPTION
https://github.com/Sorcery/sorcery/blob/ba45f1823948702bdbae3f24b2f20e2a6ee239ab/lib/sorcery/controller.rb#L43
This code is implemented that deleted sessions is restored to new session. it cannot protect session fixation attacks, is it? So, I fixed its bug once.

In reset_sorcery_session, I fixed that it reset session used in sorcery and restore sessions that not used in sorcery.

Further more, by fixing it, when we log in or out by sorcery, sessions that not used in sorcery do not delete. Namely,  when other authentication gem, for example devise, is being using in same apps, we will not be forced to log out!
thank you.