### PR TITLE
Fix for not-copied migration files

### DIFF
--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -61,7 +61,7 @@ module Sorcery
       # Copy the migrations files to db/migrate folder
       def copy_migration_files
         # Copy core migration file in all cases except when you pass --only-submodules.
-        return unless defined?(Sorcery::Generators::InstallGenerator::ActiveRecord)
+        return unless defined?(ActiveRecord)
         migration_template 'migration/core.rb', 'db/migrate/sorcery_core.rb', migration_class_name: migration_class_name unless only_submodules?
 
         if submodules


### PR DESCRIPTION
`Sorcery::Generators::InstallGenerator::ActiveRecord` is not defined
and the purpose of this guard is to know whether orm is ActiveRecord or not.
Therefore, return early when top-level ActiveRecord is not defined.

This patch will solve #119