### PR TITLE
send activation email after the commit in transactional databases

### DIFF
--- a/lib/sorcery/adapters/active_record_adapter.rb
+++ b/lib/sorcery/adapters/active_record_adapter.rb
@@ -35,7 +35,7 @@ module Sorcery
         end
 
         def define_callback(time, event, method_name, options = {})
-          @klass.send "#{time}_#{event}", method_name, options.slice(:if)
+          @klass.send "#{time}_#{event}", method_name, options.slice(:if, :on)
         end
 
         def find_by_oauth_credentials(provider, uid)

--- a/lib/sorcery/adapters/mongoid_adapter.rb
+++ b/lib/sorcery/adapters/mongoid_adapter.rb
@@ -33,7 +33,15 @@ module Sorcery
         end
 
         def define_callback(time, event, method_name, options={})
-          @klass.send "#{time}_#{event}", method_name, options.slice(:if)
+          callback_name = if event == :commit && options[:on] == :create
+                            "#{time}_create"
+                          elsif event == :commit
+                            "#{time}_save"
+                          else
+                            "#{time}_#{event}"
+                          end
+
+          @klass.send callback_name, method_name, options.slice(:if)
         end
 
         def credential_regex(credential)

--- a/lib/sorcery/adapters/mongoid_adapter.rb
+++ b/lib/sorcery/adapters/mongoid_adapter.rb
@@ -33,10 +33,10 @@ module Sorcery
         end
 
         def define_callback(time, event, method_name, options={})
-          @klass.send callback_name(type, event, options), method_name, options.slice(:if)
+          @klass.send callback_name(time, event, options), method_name, options.slice(:if)
         end
 
-        def callback_name(type, event, options)
+        def callback_name(time, event, options)
           if event == :commit
             options[:on] == :create ? "#{time}_create" : "#{time}_save"
           else

--- a/lib/sorcery/adapters/mongoid_adapter.rb
+++ b/lib/sorcery/adapters/mongoid_adapter.rb
@@ -33,15 +33,15 @@ module Sorcery
         end
 
         def define_callback(time, event, method_name, options={})
-          callback_name = if event == :commit && options[:on] == :create
-                            "#{time}_create"
-                          elsif event == :commit
-                            "#{time}_save"
-                          else
-                            "#{time}_#{event}"
-                          end
+          @klass.send callback_name(type, event, options), method_name, options.slice(:if)
+        end
 
-          @klass.send callback_name, method_name, options.slice(:if)
+        def callback_name(type, event, options)
+          if event == :commit
+            options[:on] == :create ? "#{time}_create" : "#{time}_save"
+          else
+            "#{time}_#{event}"
+          end
         end
 
         def credential_regex(credential)

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -107,14 +107,14 @@ module Sorcery
             end
             mail
           end
-          
+
           # Increment access_count_to_reset_password_page attribute.
           # For example, access_count_to_reset_password_page attribute is over 1, which
           # means the user doesn't have a right to access.
           def increment_password_reset_page_access_counter
             sorcery_adapter.increment(self.sorcery_config.reset_password_page_access_count_attribute_name)
           end
-          
+
           # Reset access_count_to_reset_password_page attribute into 0.
           # This is expected to be used after sending an instruction email.
           def reset_password_reset_page_access_counter
@@ -126,7 +126,7 @@ module Sorcery
           def change_password!(new_password)
             clear_reset_password_token
             send(:"#{sorcery_config.password_attribute_name}=", new_password)
-            sorcery_adapter.save
+            sorcery_adapter.save raise_on_failure: true
           end
 
           protected

--- a/lib/sorcery/model/submodules/user_activation.rb
+++ b/lib/sorcery/model/submodules/user_activation.rb
@@ -45,7 +45,7 @@ module Sorcery
             # don't setup activation if no password supplied - this user is created automatically
             sorcery_adapter.define_callback :before, :create, :setup_activation, if: proc { |user| user.send(sorcery_config.password_attribute_name).present? }
             # don't send activation needed email if no crypted password created - this user is external (OAuth etc.)
-            sorcery_adapter.define_callback :after, :create, :send_activation_needed_email!, if: :send_activation_needed_email?
+            sorcery_adapter.define_callback :after, :commit, :send_activation_needed_email!, on: :create, if: :send_activation_needed_email?
           end
 
           base.sorcery_config.after_config << :validate_mailer_defined

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ RSpec.configure do |config|
   config.include RSpec::Rails::ControllerExampleGroup, file_path: /controller(.)*_spec.rb$/
   config.mock_with :rspec
 
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   config.before(:suite) { setup_orm }
   config.after(:suite) { teardown_orm }


### PR DESCRIPTION
Use `after_commit on: :create` instead of `after_create` callback for sending activation email. It's necessary because of `after_create` is located in a transaction. There is no guarantee that user will exist when email will start building.

More details http://codebeerstartups.com/2012/11/use-after_commit-instead-of-active-record-callbacks-to-avoid-unexpected-errors/

Also added a patch to mongo `define callback`. Let me know if you need more info about this issue.