### PR TITLE
Support injecting helpers into ActionController::API

### DIFF
--- a/lib/sorcery/engine.rb
+++ b/lib/sorcery/engine.rb
@@ -8,9 +8,11 @@ module Sorcery
     config.sorcery = ::Sorcery::Controller::Config
 
     initializer 'extend Controller with sorcery' do
-      ActionController::Base.send(:include, Sorcery::Controller)
-      ActionController::Base.helper_method :current_user
-      ActionController::Base.helper_method :logged_in?
+      ActiveSupport.on_load('action_controller') do
+        send(:include, Sorcery::Controller)
+        helper_method :current_user
+        helper_method :logged_in?
+      end
     end
   end
 end


### PR DESCRIPTION
Rails API apps use the lighter alternative to ActionController::Base.
This adds support for injecting these helpers into either action
controller base class that the consuming application happens to inherit
from.

This is a step towards full support in rails api mode. 