### PR TITLE
Pass along `remember_me` to `#auto_login`

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -47,7 +47,7 @@ module Sorcery
           end
           form_authenticity_token
 
-          auto_login(user)
+          auto_login(user, credentials[2])
           after_login!(user, credentials)
 
           block_given? ? yield(current_user, nil) : current_user

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -18,7 +18,6 @@ module Sorcery
             merge_remember_me_defaults!
           end
           Config.login_sources << :login_from_cookie
-          Config.after_login << :remember_me_if_asked_to
           Config.before_logout << :forget_me!
         end
 
@@ -50,12 +49,6 @@ module Sorcery
           end
 
           protected
-
-          # calls remember_me! if a third credential was passed to the login method.
-          # Runs as a hook after login.
-          def remember_me_if_asked_to(_user, credentials)
-            remember_me! if credentials.size == 3 && credentials[2] && credentials[2] != '0'
-          end
 
           # Checks the cookie for a remember me token, tried to find a user with that token
           # and logs the user in if found.


### PR DESCRIPTION
When overriding the `#auto_login` method when implementing our own
session handling we never got passed the `should_remember` value from
the `#login` method.

The `Sorcery::Controller::Submodules::RememberMe` never used the value
of the `should_remember` arguments passed to the `#auto_login` method
and instead relied on a callback being executed.

This commits removes the callback and instead calls the `#remember_me!`
method from the `#auto_login` method instead.