### PR TITLE
Remove `publish_actions` permission for facebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Respect SessionTimeout on login via RememberMe [#102](https://github.com/Sorcery/sorcery/pull/102)
 * Added `demodulize` on authentication class name association name fetch [#147](https://github.com/Sorcery/sorcery/pull/147)
 * Remove Gemnasium badge [#140](https://github.com/Sorcery/sorcery/pull/140)
+* Remove `publish_actions` permission for facebook [#139](https://github.com/Sorcery/sorcery/pull/139)
 
 ## 0.12.0
 

--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -119,7 +119,7 @@ Rails.application.config.sorcery.configure do |config|
   # config.facebook.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=facebook"
   # config.facebook.user_info_path = "me?fields=email"
   # config.facebook.user_info_mapping = {:email => "email"}
-  # config.facebook.access_permissions = ["email", "publish_actions"]
+  # config.facebook.access_permissions = ["email"]
   # config.facebook.display = "page"
   # config.facebook.api_version = "v2.3"
   # config.facebook.parse = :json


### PR DESCRIPTION
In facebook, `publish_actions` permission has been deleted.
https://developers.facebook.com/docs/graph-api/changelog/breaking-changes?locale=en_US

So, it is not good that `publish_actions` still exists in template file. 


