### PR TITLE
Add openid connect provider and allow to attach query params

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -8,6 +8,7 @@ module Sorcery
           base.send(:include, InstanceMethods)
 
           require 'sorcery/providers/base'
+          require 'sorcery/providers/openid'
           require 'sorcery/providers/facebook'
           require 'sorcery/providers/twitter'
           require 'sorcery/providers/vk'
@@ -66,7 +67,7 @@ module Sorcery
             sorcery_fixup_callback_url @provider
             if @provider.respond_to?(:login_url) && @provider.has_callback?
               @provider.state = args[:state]
-              return @provider.login_url(params, session)
+              return @provider.login_url(params, session, args)
             else
               return nil
             end

--- a/lib/sorcery/protocols/oauth2.rb
+++ b/lib/sorcery/protocols/oauth2.rb
@@ -8,13 +8,16 @@ module Sorcery
       end
 
       def authorize_url(options = {})
-        client = build_client(options)
-        client.auth_code.authorize_url(
+        query_params = {
           redirect_uri: @callback_url,
           scope: @scope,
           display: @display,
           state: @state
-        )
+        }
+        params = options.extract! :params
+        query_params.merge!(params[:params]) unless params.empty?
+        client = build_client(options)
+        client.auth_code.authorize_url(query_params)
       end
 
       def get_access_token(args, options = {})

--- a/lib/sorcery/providers/openid.rb
+++ b/lib/sorcery/providers/openid.rb
@@ -1,0 +1,45 @@
+module Sorcery
+  module Providers
+    class Openid < Base
+      include Protocols::Oauth2
+
+      attr_accessor :auth_url, :scope, :token_url, :user_info_url
+
+      def initialize
+        super
+
+        @auth_url      = '/authorize'
+        @token_url     = '/token'
+        @user_info_url = '/userinfo'
+        @scope         = 'openid'
+      end
+
+      def get_user_hash(access_token)
+        response = access_token.get(user_info_url)
+        auth_hash(access_token).tap do |h|
+          h[:user_info] = JSON.parse(response.body)
+          h[:uid] = h[:user_info]['sub']
+        end
+      end
+
+      # calculates and returns the url to which the user should be redirected,
+      # to get authenticated at the external provider's site.
+      def login_url(_params, _session, args = {})
+        options = {
+          authorize_url: auth_url,
+          params: args
+        }
+        authorize_url(options)
+      end
+
+      # tries to login the user from access token
+      def process_callback(params, _session)
+        args = {}.tap do |a|
+          a[:code] = params[:code] if params[:code]
+        end
+
+        get_access_token(args, ssl: { verify: false }, token_url: token_url, token_method: :post)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I was trying to integrate an openid connect provider with any of the existing external providers. None of which is exactly supporting the standard.

With this change an external provider "openid" is added which is compatible with any provider implementing the standard openid connect protocol. In order to allow using additional parameters defined in openid conenct the oauth2 module was extended.

Let me know what you think of this. If this is something you would like to pull, I can enhance with test code and documentation.
