### PR TITLE
update_failed_logins_count is called twice when login failed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'pry'
 gem 'rails', '~> 5.2.0'
 gem 'rails-controller-testing'
-gem 'sqlite3'
+gem 'sqlite3', '~> 1.3.6'
 
 gemspec

--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -30,9 +30,16 @@ module Sorcery
             end
             merge_activity_logging_defaults!
           end
-          Config.after_login    << :register_login_time_to_db
-          Config.after_login    << :register_last_ip_address
-          Config.before_logout  << :register_logout_time_to_db
+          # FIXME: There is likely a more elegant way to safeguard these callbacks.
+          unless Config.after_login.include?(:register_login_time_to_db)
+            Config.after_login << :register_login_time_to_db
+          end
+          unless Config.after_login.include?(:register_last_ip_address)
+            Config.after_login << :register_last_ip_address
+          end
+          unless Config.before_logout.include?(:register_logout_time_to_db)
+            Config.before_logout << :register_logout_time_to_db
+          end
           base.after_action :register_last_activity_time_to_db
         end
 

--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -10,9 +10,13 @@ module Sorcery
       module BruteForceProtection
         def self.included(base)
           base.send(:include, InstanceMethods)
-
-          Config.after_login << :reset_failed_logins_count!
-          Config.after_failed_login << :update_failed_logins_count!
+          # FIXME: There is likely a more elegant way to safeguard these callbacks.
+          unless Config.after_login.include?(:reset_failed_logins_count!)
+            Config.after_login << :reset_failed_logins_count!
+          end
+          unless Config.after_failed_login.include?(:update_failed_logins_count!)
+            Config.after_failed_login << :update_failed_logins_count!
+          end
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/http_basic_auth.rb
+++ b/lib/sorcery/controller/submodules/http_basic_auth.rb
@@ -19,7 +19,10 @@ module Sorcery
             end
             merge_http_basic_auth_defaults!
           end
-          Config.login_sources << :login_from_basic_auth
+          # FIXME: There is likely a more elegant way to safeguard these callbacks.
+          unless Config.login_sources.include?(:login_from_basic_auth)
+            Config.login_sources << :login_from_basic_auth
+          end
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -17,8 +17,13 @@ module Sorcery
             end
             merge_remember_me_defaults!
           end
-          Config.login_sources << :login_from_cookie
-          Config.before_logout << :forget_me!
+          # FIXME: There is likely a more elegant way to safeguard these callbacks.
+          unless Config.login_sources.include?(:login_from_cookie)
+            Config.login_sources << :login_from_cookie
+          end
+          unless Config.before_logout.include?(:forget_me!)
+            Config.before_logout << :forget_me!
+          end
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -23,8 +23,13 @@ module Sorcery
             end
             merge_session_timeout_defaults!
           end
-          Config.after_login << :register_login_time
-          Config.after_remember_me << :register_login_time
+          # FIXME: There is likely a more elegant way to safeguard these callbacks.
+          unless Config.after_login.include?(:register_login_time)
+            Config.after_login << :register_login_time
+          end
+          unless Config.after_remember_me.include?(:register_login_time)
+            Config.after_remember_me << :register_login_time
+          end
           base.prepend_before_action :validate_session
         end
 

--- a/lib/sorcery/engine.rb
+++ b/lib/sorcery/engine.rb
@@ -9,11 +9,9 @@ module Sorcery
 
     initializer 'extend Controller with sorcery' do
       # TODO: Should this include a modified version of the helper methods?
-      if defined?(ActionController::API)
+      if defined?(ActionController::API) && Rails.application.config.api_only
         ActionController::API.send(:include, Sorcery::Controller)
-      end
-
-      if defined?(ActionController::Base)
+      else
         ActionController::Base.send(:include, Sorcery::Controller)
         ActionController::Base.helper_method :current_user
         ActionController::Base.helper_method :logged_in?

--- a/lib/sorcery/engine.rb
+++ b/lib/sorcery/engine.rb
@@ -9,9 +9,11 @@ module Sorcery
 
     initializer 'extend Controller with sorcery' do
       # TODO: Should this include a modified version of the helper methods?
-      if defined?(ActionController::API) && Rails.application.config.api_only
+      if defined?(ActionController::API)
         ActionController::API.send(:include, Sorcery::Controller)
-      else
+      end
+
+      if defined?(ActionController::Base)
         ActionController::Base.send(:include, Sorcery::Controller)
         ActionController::Base.helper_method :current_user
         ActionController::Base.helper_method :logged_in?


### PR DESCRIPTION
Failed_logins_count is incremented by 2 when login failed.

login failed request SQL log
```
CACHE User Load (0.0ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User') AND `users`.`deleted_at` IS NULL AND `users`.`email` = 'unko@example.com' ORDER BY `users`.`id` ASC LIMIT 1  [["LIMIT", 1]]
SQL (5.8ms)  UPDATE `users` SET `failed_logins_count` = COALESCE(`failed_logins_count`, 0) + 1 WHERE `users`.`type` IN ('User') AND `users`.`id` = 1702
User Load (0.7ms)  SELECT  `users`.* FROM `users` WHERE `users`.`type` IN ('User') AND `users`.`deleted_at` IS NULL AND `users`.`email` = 'unko@example.com' ORDER BY `users`.`id` ASC LIMIT 1
SQL (3.2ms)  UPDATE `users` SET `failed_logins_count` = COALESCE(`failed_logins_count`, 0) + 1 WHERE `users`.`type` IN ('User') AND `users`.`id` = 1702
```

Config.after_failed_login and Config.after_login are set doubly
```
(byebug) Rails.application.config.sorcery.submodules
[:user_activation, :reset_password, :activity_logging, :brute_force_protection, :external]
(byebug) Sorcery::Controller::Config.after_login
[:register_login_time_to_db, :register_last_ip_address, :reset_failed_logins_count!, :register_login_time_to_db, :register_last_ip_address, :reset_failed_logins_count!]
(byebug) Sorcery::Controller::Config.after_failed_login
[:update_failed_logins_count!, :update_failed_logins_count!]
```