### PR TITLE
Fix `rvm get stable` breaking due to new maintainer signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ before_script:
   - mysql -e 'create database sorcery_test;'
 
 before_install:
-  - gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-  - rvm get stable --auto-dotfiles
   - gem update bundler
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
   - mysql -e 'create database sorcery_test;'
 
 before_install:
-  - gem update bundler
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - mysql -e 'create database sorcery_test;'
 
 before_install:
+  - gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
   - rvm get stable --auto-dotfiles
   - gem update bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,31 +7,9 @@ rvm:
 
 gemfile:
   - Gemfile
-  - gemfiles/active_record_rails_40.gemfile
-  - gemfiles/active_record_rails_41.gemfile
-  - gemfiles/active_record_rails_42.gemfile
 
 before_script:
   - mysql -e 'create database sorcery_test;'
 
 before_install:
-  - gem install bundler -v '~> 1.0'
-
-matrix:
-  exclude:
-    - rvm: 2.2.9
-      gemfile: gemfiles/active_record_rails_40.gemfile
-    - rvm: 2.3.6
-      gemfile: gemfiles/active_record_rails_40.gemfile
-    - rvm: 2.4.3
-      gemfile: gemfiles/active_record_rails_40.gemfile
-    - rvm: 2.4.3
-      gemfile: gemfiles/active_record_rails_41.gemfile
-    - rvm: 2.4.3
-      gemfile: gemfiles/active_record_rails_42.gemfile
-    - rvm: 2.5.0
-      gemfile: gemfiles/active_record_rails_40.gemfile
-    - rvm: 2.5.0
-      gemfile: gemfiles/active_record_rails_41.gemfile
-    - rvm: 2.5.0
-      gemfile: gemfiles/active_record_rails_42.gemfile
+  - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - mysql -e 'create database sorcery_test;'
 
 before_install:
-  - gem update bundler
+  - gem install bundler -v '~> 1.0'
 
 matrix:
   exclude:

--- a/gemfiles/active_record_rails_40.gemfile
+++ b/gemfiles/active_record_rails_40.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.0.1'
-gem 'sqlite3', platform: :mri
-
-gemspec path: '..'

--- a/gemfiles/active_record_rails_41.gemfile
+++ b/gemfiles/active_record_rails_41.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.1.0'
-gem 'sqlite3', platform: :mri
-
-gemspec path: '..'

--- a/gemfiles/active_record_rails_42.gemfile
+++ b/gemfiles/active_record_rails_42.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.2.0'
-gem 'sqlite3', platform: :mri
-
-gemspec path: '..'


### PR DESCRIPTION
See related issues:
[rvm/rvm#4520](https://github.com/rvm/rvm/issues/4520)
[rvm/rvm#4561](https://github.com/rvm/rvm/issues/4561)

Should be solved by (but isn't yet):
[travis-ci/travis-build#1634](https://github.com/travis-ci/travis-build/pull/1634)