### PR TITLE
Add failure reason argument for `after_failed_login` callback

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -36,7 +36,7 @@ module Sorcery
 
         user_class.authenticate(*credentials) do |user, failure_reason|
           if failure_reason
-            after_failed_login!(credentials)
+            after_failed_login!(credentials, failure_reason)
 
             yield(user, failure_reason) if block_given?
 
@@ -143,8 +143,8 @@ module Sorcery
         Config.after_login.each { |c| send(c, user, credentials) }
       end
 
-      def after_failed_login!(credentials)
-        Config.after_failed_login.each { |c| send(c, credentials) }
+      def after_failed_login!(credentials, failure_reason)
+        Config.after_failed_login.each { |c| send(c, credentials, failure_reason) }
       end
 
       def before_logout!

--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -20,7 +20,7 @@ module Sorcery
 
           # Increments the failed logins counter on every failed login.
           # Runs as a hook after a failed login.
-          def update_failed_logins_count!(credentials)
+          def update_failed_logins_count!(credentials, _failure_reason)
             user = user_class.sorcery_adapter.find_by_credentials(credentials)
             user.register_failed_login! if user
           end


### PR DESCRIPTION
Follow https://github.com/Sorcery/sorcery/pull/41, maybe we need the failure reason in callbacks