### PR TITLE
Fix typo in the base providers :auth_hash

### DIFF
--- a/lib/sorcery/providers/base.rb
+++ b/lib/sorcery/providers/base.rb
@@ -21,7 +21,7 @@ module Sorcery
         token_hash[:token] = access_token.token if access_token.respond_to?(:token)
         token_hash[:refresh_token] = access_token.refresh_token if access_token.respond_to?(:refresh_token)
         token_hash[:expires_at] = access_token.expires_at if access_token.respond_to?(:expires_at)
-        token_hash[:expires_in] = access_token.expires_at if access_token.respond_to?(:expires_in)
+        token_hash[:expires_in] = access_token.expires_in if access_token.respond_to?(:expires_in)
         token_hash
       end
 


### PR DESCRIPTION
Based on the :respond_to? it looks like this was intended to be storing
the :expires_in method.