### PR TITLE
Add limitless counting failed login function

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -465,6 +465,11 @@ Rails.application.config.sorcery.configure do |config|
     #
     # user.login_lock_time_period =
 
+    # When true, sorcery continue to count failed login after reached limit.
+    # Default: `false`
+    #
+    # user.limitless_counting_failed_login =
+
     # Unlock token attribute name
     # Default: `:unlock_token`
     #

--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -26,7 +26,7 @@ module Sorcery
           # Runs as a hook after a failed login.
           def update_failed_logins_count!(credentials)
             user = user_class.sorcery_adapter.find_by_credentials(credentials)
-            user.register_failed_login! if user
+            user.register_failed_login!(credentials[1]) if user
           end
 
           # Resets the failed logins counter.

--- a/spec/shared_examples/user_brute_force_protection_shared_examples.rb
+++ b/spec/shared_examples/user_brute_force_protection_shared_examples.rb
@@ -1,5 +1,8 @@
 shared_examples_for 'rails_3_brute_force_protection_model' do
-  let(:user) { create_new_user }
+  let(:email) { 'foo@bar.com' }
+  let(:valid_password) { 'secret' }
+  let(:invalid_password) { 'foobar' }
+  let(:user) { create_new_user(username: 'foo_bar', email: email, password: valid_password) }
   before(:each) do
     User.sorcery_adapter.delete_all
   end
@@ -38,6 +41,12 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
       expect(config.login_lock_time_period).to eq 2.hours
     end
 
+    it "enables configuration option 'limitless_counting_failed_login'" do
+      sorcery_model_property_set(:limitless_counting_failed_login, :my_limitless_counting_failed_login)
+
+      expect(config.limitless_counting_failed_login).to eq :my_limitless_counting_failed_login
+    end
+
     describe '#login_locked?' do
       it 'is locked' do
         user.send("#{config.lock_expires_at_attribute_name}=", Time.now + 5.days)
@@ -51,12 +60,12 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
     end
   end
 
-  describe '#register_failed_login!' do
+  describe '#register_failed_login!(password)' do
     it 'locks user when number of retries reached the limit' do
       expect(user.lock_expires_at).to be_nil
 
       sorcery_model_property_set(:consecutive_login_retries_amount_limit, 1)
-      user.register_failed_login!
+      user.register_failed_login!(invalid_password)
       lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
 
       expect(lock_expires_at).not_to be_nil
@@ -69,7 +78,7 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
         sorcery_model_property_set(:login_lock_time_period, 0)
         sorcery_model_property_set(:unlock_token_mailer, SorceryMailer)
 
-        3.times { user.register_failed_login! }
+        3.times { user.register_failed_login!(invalid_password) }
 
         expect(ActionMailer::Base.deliveries.size).to eq 0
       end
@@ -84,15 +93,45 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
       end
 
       it 'does not automatically send unlock email' do
-        3.times { user.register_failed_login! }
+        3.times { user.register_failed_login!(invalid_password) }
 
         expect(ActionMailer::Base.deliveries.size).to eq 1
       end
 
       it 'generates unlock token before mail is sent' do
-        3.times { user.register_failed_login! }
+        3.times { user.register_failed_login!(invalid_password) }
 
         expect(ActionMailer::Base.deliveries.last.body.to_s.match(user.unlock_token)).not_to be_nil
+      end
+    end
+
+    context 'limitless_counting_failed_login is true' do
+      before do
+        sorcery_model_property_set(:consecutive_login_retries_amount_limit, 1)
+        sorcery_model_property_set(:limitless_counting_failed_login, true)
+        2.times { user.register_failed_login!(invalid_password) }
+      end
+
+      it 'increment failed logins count attribute with invalid password after reached limit' do
+        expect(user.failed_logins_count).to eq 2
+      end
+
+      it 'does not increment failed logins count attribute with valid password after reached limit' do
+        user.register_failed_login!(valid_password)
+        expect(user.failed_logins_count).to eq 2
+      end
+    end
+
+    context 'limitless_counting_failed_login is false' do
+      before do
+        sorcery_model_property_set(:consecutive_login_retries_amount_limit, 1)
+        sorcery_model_property_set(:limitless_counting_failed_login, false)
+      end
+
+      it 'does not increment failed logins count attribute after reached limit' do
+        user.register_failed_login!(invalid_password)
+
+        expect(user.failed_logins_count).to eq 1
       end
     end
   end
@@ -101,13 +140,13 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
     it 'unlocks after lock time period passes' do
       sorcery_model_property_set(:consecutive_login_retries_amount_limit, 2)
       sorcery_model_property_set(:login_lock_time_period, 0.2)
-      2.times { user.register_failed_login! }
+      2.times { user.register_failed_login!(invalid_password) }
 
       lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
       expect(lock_expires_at).not_to be_nil
 
       Timecop.travel(Time.now.in_time_zone + 0.3)
-      User.authenticate('bla@bla.com', 'secret')
+      User.authenticate(email, valid_password)
 
       lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
       expect(lock_expires_at).to be_nil
@@ -118,12 +157,12 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
       sorcery_model_property_set(:consecutive_login_retries_amount_limit, 2)
       sorcery_model_property_set(:login_lock_time_period, 0)
 
-      2.times { user.register_failed_login! }
+      2.times { user.register_failed_login!(invalid_password) }
 
       unlock_date = user.lock_expires_at
       Timecop.travel(Time.now.in_time_zone + 1)
 
-      user.register_failed_login!
+      user.register_failed_login!(invalid_password)
 
       expect(user.lock_expires_at.to_s).to eq unlock_date.to_s
       Timecop.return
@@ -135,7 +174,7 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
       sorcery_model_property_set(:consecutive_login_retries_amount_limit, 2)
       sorcery_model_property_set(:login_lock_time_period, 0)
       sorcery_model_property_set(:unlock_token_mailer, SorceryMailer)
-      3.times { user.register_failed_login! }
+      3.times { user.register_failed_login!(invalid_password) }
 
       expect(user.unlock_token).not_to be_nil
 


### PR DESCRIPTION
Hi.

This function is adding limitless counting 'failed login'.
I think, if stopped counting 'failed login' after reached limit, we can't tell the reason of lock either user's action or brute force attack, so I added.

If you don't need, please close this PR
Thanks.