### PR TITLE
Add discord provider

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -220,6 +220,12 @@ Rails.application.config.sorcery.configure do |config|
   # config.line.secret = ""
   # config.line.callback_url = "http://mydomain.com:3000/oauth/callback?provider=line"
 
+  # For infromation about Discord API
+  # https://discordapp.com/developers/docs/topics/oauth2
+  # config.discord.key = "xxxxxx"
+  # config.discord.secret = "xxxxxx"
+  # config.discord.callback_url = "http://localhost:3000/oauth/callback?provider=discord"
+  # config.discord.scope = "email guilds"
   # --- user config ---
   config.user_config do |user|
     # -- core --

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -26,6 +26,7 @@ module Sorcery
           require 'sorcery/providers/instagram'
           require 'sorcery/providers/auth0'
           require 'sorcery/providers/line'
+          require 'sorcery/providers/discord'
 
           Config.module_eval do
             class << self

--- a/lib/sorcery/providers/discord.rb
+++ b/lib/sorcery/providers/discord.rb
@@ -1,0 +1,52 @@
+module Sorcery
+  module Providers
+    # This class adds support for OAuth with discordapp.com
+
+    class Discord < Base
+      include Protocols::Oauth2
+
+      attr_accessor :auth_path, :scope, :token_url, :user_info_path
+
+      def initialize
+        super
+
+        @scope          = 'identify'
+        @site           = 'https://discordapp.com/'
+        @auth_path      = '/api/oauth2/authorize'
+        @token_url      = '/api/oauth2/token'
+        @user_info_path = '/api/users/@me'
+        @state          = SecureRandom.hex(16)
+      end
+
+      def get_user_hash(access_token)
+        response = access_token.get(user_info_path)
+        body = JSON.parse(response.body)
+        auth_hash(access_token).tap do |h|
+          h[:user_info] = body
+          h[:uid] = body['id']
+        end
+      end
+
+      # calculates and returns the url to which the user should be redirected,
+      # to get authenticated at the external provider's site.
+      def login_url(_params, _session)
+        authorize_url(authorize_url: auth_path)
+      end
+
+      # tries to login the user from access token
+      def process_callback(params, _session)
+        args = {}.tap do |a|
+          a[:code] = params[:code] if params[:code]
+        end
+        get_access_token(
+          args,
+          token_url: token_url,
+          client_id: @key,
+          client_secret: @secret,
+          grant_type: 'authorization_code',
+          token_method: :post
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -155,7 +155,7 @@ describe SorceryController, active_record: true, type: :controller do
       expect(flash[:notice]).to eq 'Success!'
     end
 
-    %i[github google liveid vk salesforce paypal slack wechat microsoft instagram auth0].each do |provider|
+    %i[github google liveid vk salesforce paypal slack wechat microsoft instagram auth0 discord].each do |provider|
       describe "with #{provider}" do
         it 'login_at redirects correctly' do
           get :"login_at_test_#{provider}"
@@ -217,6 +217,7 @@ describe SorceryController, active_record: true, type: :controller do
           instagram
           auth0
           line
+          discord
         ]
       )
 
@@ -261,6 +262,9 @@ describe SorceryController, active_record: true, type: :controller do
       sorcery_controller_external_property_set(:line, :key, "eYVNBjBDi33aa9GkA3w")
       sorcery_controller_external_property_set(:line, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
       sorcery_controller_external_property_set(:line, :callback_url, "http://blabla.com")
+      sorcery_controller_external_property_set(:discord, :key, 'eYVNBjBDi33aa9GkA3w')
+      sorcery_controller_external_property_set(:discord, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
+      sorcery_controller_external_property_set(:discord, :callback_url, 'http://blabla.com')
     end
 
     after(:each) do
@@ -283,7 +287,7 @@ describe SorceryController, active_record: true, type: :controller do
       expect(ActionMailer::Base.deliveries.size).to eq old_size
     end
 
-    %i[github google liveid vk salesforce paypal wechat microsoft instagram auth0].each do |provider|
+    %i[github google liveid vk salesforce paypal wechat microsoft instagram auth0 discord].each do |provider|
       it "does not send activation email to external users (#{provider})" do
         old_size = ActionMailer::Base.deliveries.size
         create_new_external_user provider
@@ -307,7 +311,7 @@ describe SorceryController, active_record: true, type: :controller do
       sorcery_reload!(%i[activity_logging external])
     end
 
-    %w[facebook github google liveid vk salesforce slack].each do |provider|
+    %w[facebook github google liveid vk salesforce slack discord].each do |provider|
       context "when #{provider}" do
         before(:each) do
           sorcery_controller_property_set(:register_login_time, true)
@@ -346,7 +350,7 @@ describe SorceryController, active_record: true, type: :controller do
 
     let(:user) { double('user', id: 42) }
 
-    %w[facebook github google liveid vk salesforce slack].each do |provider|
+    %w[facebook github google liveid vk salesforce slack discord].each do |provider|
       context "when #{provider}" do
         before(:each) do
           sorcery_model_property_set(:authentications_class, Authentication)
@@ -479,6 +483,7 @@ describe SorceryController, active_record: true, type: :controller do
         instagram
         auth0
         line
+        discord
       ]
     )
     sorcery_controller_external_property_set(:facebook, :key, 'eYVNBjBDi33aa9GkA3w')
@@ -521,6 +526,9 @@ describe SorceryController, active_record: true, type: :controller do
     sorcery_controller_external_property_set(:line, :key, "eYVNBjBDi33aa9GkA3w")
     sorcery_controller_external_property_set(:line, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
     sorcery_controller_external_property_set(:line, :callback_url, "http://blabla.com")
+    sorcery_controller_external_property_set(:discord, :key, 'eYVNBjBDi33aa9GkA3w')
+    sorcery_controller_external_property_set(:discord, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
+    sorcery_controller_external_property_set(:discord, :callback_url, 'http://blabla.com')
   end
 
   def provider_url(provider)
@@ -535,7 +543,8 @@ describe SorceryController, active_record: true, type: :controller do
       wechat: "https://open.weixin.qq.com/connect/qrconnect?appid=#{::Sorcery::Controller::Config.wechat.key}&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=snsapi_login&state=#wechat_redirect",
       microsoft: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=#{::Sorcery::Controller::Config.microsoft.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid+email+https%3A%2F%2Fgraph.microsoft.com%2FUser.Read&state",
       instagram: "https://api.instagram.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.instagram.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.instagram.scope}&state",
-      auth0: "https://sorcery-test.auth0.com/authorize?client_id=#{::Sorcery::Controller::Config.auth0.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid+profile+email&state"
+      auth0: "https://sorcery-test.auth0.com/authorize?client_id=#{::Sorcery::Controller::Config.auth0.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid+profile+email&state",
+      discord: "https://discordapp.com/api/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.discord.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=identify&state"
     }[provider]
   end
 end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -158,6 +158,10 @@ class SorceryController < ActionController::Base
     login_at(:auth0)
   end
 
+  def login_at_test_discord
+    login_at(:discord)
+  end
+
   def test_login_from_twitter
     if (@user = login_from(:twitter))
       redirect_to 'bla', notice: 'Success!'
@@ -280,6 +284,14 @@ class SorceryController < ActionController::Base
     end
   end
 
+  def test_login_from_discord
+    if (@user = login_from(:discord))
+      redirect_to 'bla', notice: 'Success!'
+    else
+      redirect_to 'blu', alert: 'Failed!'
+    end
+  end
+
   def test_return_to_with_external_twitter
     if (@user = login_from(:twitter))
       redirect_back_or_to 'bla', notice: 'Success!'
@@ -396,6 +408,14 @@ class SorceryController < ActionController::Base
 
   def test_return_to_with_external_line
     if @user = login_from(:line)
+      redirect_back_or_to 'bla', notice: 'Success!'
+    else
+      redirect_to 'blu', alert: 'Failed!'
+    end
+  end
+
+  def test_return_to_with_external_discord
+    if (@user = login_from(:discord))
       redirect_back_or_to 'bla', notice: 'Success!'
     else
       redirect_to 'blu', alert: 'Failed!'

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -33,6 +33,7 @@ AppRoot::Application.routes.draw do
     get :test_login_from_instagram
     get :test_login_from_auth0
     get :test_login_from_line
+    get :test_login_from_discord
     get :login_at_test
     get :login_at_test_twitter
     get :login_at_test_facebook
@@ -49,6 +50,7 @@ AppRoot::Application.routes.draw do
     get :login_at_test_instagram
     get :login_at_test_auth0
     get :login_at_test_line
+    get :login_at_test_discord
     get :test_return_to_with_external
     get :test_return_to_with_external_twitter
     get :test_return_to_with_external_facebook
@@ -65,6 +67,7 @@ AppRoot::Application.routes.draw do
     get :test_return_to_with_external_instagram
     get :test_return_to_with_external_auth0
     get :test_return_to_with_external_line
+    get :test_return_to_with_external_discord
     get :test_http_basic_auth
     get :some_action_making_a_non_persisted_change_to_the_user
     post :test_login_with_remember


### PR DESCRIPTION
Hello, developers of Sorcery. This gem is very helpful.

By the way, I propose a new provider of Discord. This is what I need, and I'm sure it will be useful to other Sorcery users.

About Discord's OAuth 2.0 documentation is here.
https://discordapp.com/developers/docs/topics/oauth2

I know you are busy, but could you take a look at it?

Thank you.