### PR TITLE
Fix default value of magic_login_token_expires_at

### DIFF
--- a/lib/sorcery/model/submodules/magic_login.rb
+++ b/lib/sorcery/model/submodules/magic_login.rb
@@ -35,7 +35,7 @@ module Sorcery
                              :@magic_login_mailer_class => nil,
                              :@magic_login_mailer_disabled => true,
                              :@magic_login_email_method_name => :magic_login_email,
-                             :@magic_login_expiration_period => 15 * 60,
+                             :@magic_login_expiration_period => nil,
                              :@magic_login_time_between_emails => 5 * 60)
 
             reset!

--- a/spec/shared_examples/user_magic_login_shared_examples.rb
+++ b/spec/shared_examples/user_magic_login_shared_examples.rb
@@ -60,9 +60,26 @@ shared_examples_for 'magic_login_model' do
 
     describe '#generate_magic_login_token!' do
       context 'magic_login_token is nil' do
-        it "magic_login_token_expires_at and magic_login_email_sent_at aren't nil " do
+        context 'magic_login_expiration_period is nil' do
+          it "magic_login_token_expires_at is nil" do
+            user.generate_magic_login_token!
+            expect(user.magic_login_token_expires_at).to be_nil
+          end
+        end
+
+        context "magic_login_expiration_period isn't nil" do
+          before do
+            sorcery_model_property_set(:magic_login_expiration_period, 15 * 60)
+          end
+
+          it "magic_login_token_expires_at isn't nil" do
+            user.generate_magic_login_token!
+            expect(user.magic_login_token_expires_at).not_to be_nil
+          end
+        end
+
+        it "magic_login_email_sent_at isn't nil" do
           user.generate_magic_login_token!
-          expect(user.magic_login_token_expires_at).not_to be_nil
           expect(user.magic_login_email_sent_at).not_to be_nil
         end
 


### PR DESCRIPTION
Hello! 
I fixed something related to `MagicLogin` submodule

In the initializer, the comment says default value of `magic_login_expiration_period` is nil.

https://github.com/Sorcery/sorcery/blob/ae4141e7059fa5c79d4135e81efb839a016d39ac/lib/generators/sorcery/templates/initializer.rb#L438

but `MagicLogin` initializer set not null value to `magic_login_token_expires_at`

https://github.com/Sorcery/sorcery/blob/c6680472c8858a9e53cd6f660f4cf8d3a70f4acb/lib/sorcery/model/submodules/magic_login.rb#L38

so I fixed default value of `magic_login_token_expires_at` for the comment to be correct and fix spec.