### PR TITLE
Ignore cookies when undefined cookies in Remember Me

### DIFF
--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -59,7 +59,7 @@ module Sorcery
           # and logs the user in if found.
           # Runs as a login source. See 'current_user' method for how it is used.
           def login_from_cookie
-            user = cookies.signed[:remember_me_token] && user_class.sorcery_adapter.find_by_remember_me_token(cookies.signed[:remember_me_token])
+            user = cookies.signed[:remember_me_token] && user_class.sorcery_adapter.find_by_remember_me_token(cookies.signed[:remember_me_token]) if defined? cookies
             if user && user.has_remember_me_token?
               set_remember_me_cookie!(user)
               session[:user_id] = user.id.to_s


### PR DESCRIPTION
Hello!
I fixed `Remember Me` submodule.

When using `Remember Me` submodule, `NoMethodError` occurs on controllers that do not define cookies such as API.
I fixed to read cookies only if cookies are defined.