### PR TITLE
Allow for custom providers with multi-word class names.

### DIFF
--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -38,7 +38,7 @@ module Sorcery
                 providers.each do |name|
                   class_eval <<-RUBY, __FILE__, __LINE__ + 1
                     def self.#{name}
-                      @#{name} ||= Sorcery::Providers.const_get('#{name}'.to_s.capitalize).new
+                      @#{name} ||= Sorcery::Providers.const_get('#{name}'.to_s.classify).new
                     end
                   RUBY
                 end

--- a/lib/sorcery/version.rb
+++ b/lib/sorcery/version.rb
@@ -1,3 +1,3 @@
 module Sorcery
-  VERSION = '0.14.0'.freeze
+  VERSION = '0.15.0'.freeze
 end

--- a/lib/sorcery/version.rb
+++ b/lib/sorcery/version.rb
@@ -1,3 +1,3 @@
 module Sorcery
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.14.0'.freeze
 end

--- a/spec/providers/example_provider_spec.rb
+++ b/spec/providers/example_provider_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sorcery/providers/base'
+
+describe Sorcery::Providers::ExampleProvider do
+  before(:all) do
+    sorcery_reload!([:external])
+    sorcery_controller_property_set(:external_providers, [:example_provider])
+  end
+
+  context 'fetching a multi-word custom provider' do
+    it 'returns the provider' do
+      expect(Sorcery::Controller::Config.example_provider).to be_a(Sorcery::Providers::ExampleProvider)
+    end
+  end
+end

--- a/spec/providers/example_spec.rb
+++ b/spec/providers/example_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sorcery/providers/base'
+
+describe Sorcery::Providers::Example do
+  before(:all) do
+    sorcery_reload!([:external])
+    sorcery_controller_property_set(:external_providers, [:example])
+  end
+
+  context 'fetching a single-word custom provider' do
+    it 'returns the provider' do
+      expect(Sorcery::Controller::Config.example).to be_a(Sorcery::Providers::Example)
+    end
+  end
+end

--- a/spec/support/providers/example.rb
+++ b/spec/support/providers/example.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'sorcery/providers/base'
+
+module Sorcery
+  module Providers
+    class Example < Base
+      include Protocols::Oauth2
+    end
+  end
+end

--- a/spec/support/providers/example_provider.rb
+++ b/spec/support/providers/example_provider.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'sorcery/providers/base'
+
+module Sorcery
+  module Providers
+    class ExampleProvider < Base
+      include Protocols::Oauth2
+    end
+  end
+end


### PR DESCRIPTION
Currently sorcery will not handle custom providers with names like: ExampleProvider. config.example_provider would search for a class called Example_provider rather than ExampleProvider. Using .classify rather than .capitalize will fix this.

I've added an example provider implementation under the spec/support directory, and have a test that ensures that it is loaded properly via config. The existing tests for existing providers are also coming back with successes.