### PR TITLE
Load user email in LinkedIn provider

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -88,6 +88,9 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.ca_file =
 
+  # Linkedin requires r_emailaddress scope to fetch user's email address.
+  # You can skip it if email field is not mandatory in your database (by default it is).
+  #
   # config.linkedin.key = ""
   # config.linkedin.secret = ""
   # config.linkedin.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=linkedin"

--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -89,7 +89,8 @@ Rails.application.config.sorcery.configure do |config|
   # config.ca_file =
 
   # Linkedin requires r_emailaddress scope to fetch user's email address.
-  # You can skip it if email field is not mandatory in your database (by default it is).
+  # You can skip including the email field if you use an intermediary signup form. (using build_from method).
+  # The r_emailaddress scope is only necessary if you are using the create_from method directly.
   #
   # config.linkedin.key = ""
   # config.linkedin.secret = ""

--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -91,8 +91,12 @@ Rails.application.config.sorcery.configure do |config|
   # config.linkedin.key = ""
   # config.linkedin.secret = ""
   # config.linkedin.callback_url = "http://0.0.0.0:3000/oauth/callback?provider=linkedin"
-  # config.linkedin.user_info_mapping = {first_name: "firstName", last_name: "lastName"}
-  # config.linkedin.scope = "r_basicprofile"
+  # config.linkedin.user_info_mapping = {
+  #   first_name: 'localizedFirstName',
+  #   last_name:  'localizedLastName',
+  #   email:      'emailAddress'
+  # }
+  # config.linkedin.scope = "r_liteprofile r_emailaddress"
   #
   #
   # For information about XING API:

--- a/lib/sorcery/providers/linkedin.rb
+++ b/lib/sorcery/providers/linkedin.rb
@@ -35,6 +35,7 @@ module Sorcery
       # calculates and returns the url to which the user should be redirected,
       # to get authenticated at the external provider's site.
       def login_url(_params, _session)
+        force_email_scope
         authorize_url(authorize_url: auth_url)
       end
 
@@ -54,6 +55,12 @@ module Sorcery
         email_info     = JSON.parse(email_response.body)['elements'].first
 
         user_info.merge(email_info['handle~'])
+      end
+
+      def force_email_scope
+        scope = @scope.split(' ')
+        scope.push('r_emailaddress') unless scope.include?('r_emailaddress')
+        @scope = scope.join(' ')
       end
     end
   end

--- a/lib/sorcery/providers/linkedin.rb
+++ b/lib/sorcery/providers/linkedin.rb
@@ -9,25 +9,26 @@ module Sorcery
     class Linkedin < Base
       include Protocols::Oauth2
 
-      attr_accessor :auth_url, :scope, :token_url, :user_info_url
+      attr_accessor :auth_url, :scope, :token_url, :user_info_url, :email_info_url
 
       def initialize
         super
 
-        @site          = 'https://api.linkedin.com'
-        @auth_url      = '/oauth/v2/authorization'
-        @token_url     = '/oauth/v2/accessToken'
-        @user_info_url = 'https://api.linkedin.com/v2/me'
-        @scope         = 'r_liteprofile'
-        @state         = SecureRandom.hex(16)
+        @site           = 'https://api.linkedin.com'
+        @auth_url       = '/oauth/v2/authorization'
+        @token_url      = '/oauth/v2/accessToken'
+        @user_info_url  = 'https://api.linkedin.com/v2/me'
+        @email_info_url = 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))'
+        @scope          = 'r_liteprofile r_emailaddress'
+        @state          = SecureRandom.hex(16)
       end
 
       def get_user_hash(access_token)
-        response = access_token.get(user_info_url)
+        user_info = get_user_info(access_token)
 
         auth_hash(access_token).tap do |h|
-          h[:user_info] = JSON.parse(response.body)
-          h[:uid] = h[:user_info]['id']
+          h[:user_info] = user_info
+          h[:uid]       = h[:user_info]['id']
         end
       end
 
@@ -44,6 +45,15 @@ module Sorcery
         end
 
         get_access_token(args, token_url: token_url, token_method: :post)
+      end
+
+      def get_user_info(access_token)
+        response       = access_token.get(user_info_url)
+        email_response = access_token.get(email_info_url)
+        user_info      = JSON.parse(response.body)
+        email_info     = JSON.parse(email_response.body)['elements'].first
+
+        user_info.merge(email_info['handle~'])
       end
     end
   end


### PR DESCRIPTION
As per https://github.com/Sorcery/sorcery/blob/master/lib/generators/sorcery/templates/migration/core.rb user email is a mandatory field in the DB. Thus, the recent fix for LinkedIn provider will produce an error when you try to register a new profile with it.

This fix loads user email from the additional endpoint in LinkedIn API v2 following this description: https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin?context=linkedin/consumer/context#retrieving-member-email-address