### PR TITLE
Account lock is released even if password is wrong if login lock has …

### DIFF
--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -102,20 +102,20 @@ module Sorcery
 
         set_encryption_attributes
 
-        unless user.valid_password?(credentials[1])
-          return authentication_response(user: user, failure: :invalid_password, &block)
-        end
-
-        if user.respond_to?(:active_for_authentication?) && !user.active_for_authentication?
-          return authentication_response(user: user, failure: :inactive, &block)
-        end
-
         @sorcery_config.before_authenticate.each do |callback|
           success, reason = user.send(callback)
 
           unless success
             return authentication_response(user: user, failure: reason, &block)
           end
+        end
+
+        unless user.valid_password?(credentials[1])
+          return authentication_response(user: user, failure: :invalid_password, &block)
+        end
+
+        if user.respond_to?(:active_for_authentication?) && !user.active_for_authentication?
+          return authentication_response(user: user, failure: :inactive, &block)
         end
 
         authentication_response(user: user, return_value: user, &block)


### PR DESCRIPTION
Hi.

If an incorrect password is entered after the account lock has expired, the account lock will not be released.
I thought it would be better to unlock the account even if the wrong password was entered

If you don't need, please close this PR
Thanks.