### PR TITLE
Use id instead of uid for VK provider

### DIFF
--- a/lib/sorcery/providers/vk.rb
+++ b/lib/sorcery/providers/vk.rb
@@ -37,7 +37,7 @@ module Sorcery
           user_hash[:user_info] = user_hash[:user_info]['response'][0]
           user_hash[:user_info]['full_name'] = [user_hash[:user_info]['first_name'], user_hash[:user_info]['last_name']].join(' ')
 
-          user_hash[:uid] = user_hash[:user_info]['uid']
+          user_hash[:uid] = user_hash[:user_info]['id']
           user_hash[:user_info]['email'] = access_token.params['email']
         end
         user_hash

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -427,7 +427,7 @@ describe SorceryController, active_record: true, type: :controller do
         # response for VK auth
         'response' => [
           {
-            'uid' => '123',
+            'id' => '123',
             'first_name' => 'Noam',
             'last_name' => 'Ben Ari'
           }


### PR DESCRIPTION
VK has changed the API and it returns `user_info` in such way
```
{
  email: 'someone@vk.com',
  id: 12300321
}
```
Therefore `user_hash[:user_info]['uid']` is `nil` and sorcery does not create authentication for user. This patch should fix this. 

Not sure how to add spec for this case. Let me know if you have any questions.