### PR TITLE
Remove deprecation warning in Rails 6

### DIFF
--- a/lib/sorcery/engine.rb
+++ b/lib/sorcery/engine.rb
@@ -9,11 +9,11 @@ module Sorcery
 
     initializer 'extend Controller with sorcery' do
       # TODO: Should this include a modified version of the helper methods?
-      if defined?(ActionController::API)
+      ActiveSupport.on_load(:action_controller_api) do
         ActionController::API.send(:include, Sorcery::Controller)
       end
 
-      if defined?(ActionController::Base)
+      ActiveSupport.on_load(:action_controller_base) do
         ActionController::Base.send(:include, Sorcery::Controller)
         ActionController::Base.helper_method :current_user
         ActionController::Base.helper_method :logged_in?


### PR DESCRIPTION
Hi!

First off, great gem. It's my go to for auth and user management.

Description
--

This PR removes the following deprecation warning in Rails 6:

```
DEPRECATION WARNING: Initialization autoloaded the constant ActionText::ContentHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

This autoloaded constant has been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```

Testing
--
I've manually tested this on my current project and it works.

I'm not sure of what actual tests to add so verify this with all the versions of Sorcery and supported Rails versions.

