### PR TITLE
Use Set to ensure unique arrays

### DIFF
--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -25,12 +25,12 @@ module Sorcery
             :@user_class                           => nil,
             :@submodules                           => [],
             :@not_authenticated_action             => :not_authenticated,
-            :@login_sources                        => [],
-            :@after_login                          => [],
-            :@after_failed_login                   => [],
-            :@before_logout                        => [],
-            :@after_logout                         => [],
-            :@after_remember_me                    => [],
+            :@login_sources                        => Set.new,
+            :@after_login                          => Set.new,
+            :@after_failed_login                   => Set.new,
+            :@before_logout                        => Set.new,
+            :@after_logout                         => Set.new,
+            :@after_remember_me                    => Set.new,
             :@save_return_to_url                   => true,
             :@cookie_domain                        => nil
           }

--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -30,16 +30,11 @@ module Sorcery
             end
             merge_activity_logging_defaults!
           end
-          # FIXME: There is likely a more elegant way to safeguard these callbacks.
-          unless Config.after_login.include?(:register_login_time_to_db)
-            Config.after_login << :register_login_time_to_db
-          end
-          unless Config.after_login.include?(:register_last_ip_address)
-            Config.after_login << :register_last_ip_address
-          end
-          unless Config.before_logout.include?(:register_logout_time_to_db)
-            Config.before_logout << :register_logout_time_to_db
-          end
+
+          Config.after_login << :register_login_time_to_db
+          Config.after_login << :register_last_ip_address
+          Config.before_logout << :register_logout_time_to_db
+
           base.after_action :register_last_activity_time_to_db
         end
 

--- a/lib/sorcery/controller/submodules/brute_force_protection.rb
+++ b/lib/sorcery/controller/submodules/brute_force_protection.rb
@@ -10,13 +10,9 @@ module Sorcery
       module BruteForceProtection
         def self.included(base)
           base.send(:include, InstanceMethods)
-          # FIXME: There is likely a more elegant way to safeguard these callbacks.
-          unless Config.after_login.include?(:reset_failed_logins_count!)
-            Config.after_login << :reset_failed_logins_count!
-          end
-          unless Config.after_failed_login.include?(:update_failed_logins_count!)
-            Config.after_failed_login << :update_failed_logins_count!
-          end
+
+          Config.after_login << :reset_failed_logins_count!
+          Config.after_failed_login << :update_failed_logins_count!
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/http_basic_auth.rb
+++ b/lib/sorcery/controller/submodules/http_basic_auth.rb
@@ -19,10 +19,8 @@ module Sorcery
             end
             merge_http_basic_auth_defaults!
           end
-          # FIXME: There is likely a more elegant way to safeguard these callbacks.
-          unless Config.login_sources.include?(:login_from_basic_auth)
-            Config.login_sources << :login_from_basic_auth
-          end
+
+          Config.login_sources << :login_from_basic_auth
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -17,13 +17,9 @@ module Sorcery
             end
             merge_remember_me_defaults!
           end
-          # FIXME: There is likely a more elegant way to safeguard these callbacks.
-          unless Config.login_sources.include?(:login_from_cookie)
-            Config.login_sources << :login_from_cookie
-          end
-          unless Config.before_logout.include?(:forget_me!)
-            Config.before_logout << :forget_me!
-          end
+
+          Config.login_sources << :login_from_cookie
+          Config.before_logout << :forget_me!
         end
 
         module InstanceMethods

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -23,13 +23,10 @@ module Sorcery
             end
             merge_session_timeout_defaults!
           end
-          # FIXME: There is likely a more elegant way to safeguard these callbacks.
-          unless Config.after_login.include?(:register_login_time)
-            Config.after_login << :register_login_time
-          end
-          unless Config.after_remember_me.include?(:register_login_time)
-            Config.after_remember_me << :register_login_time
-          end
+
+          Config.after_login << :register_login_time
+          Config.after_remember_me << :register_login_time
+
           base.prepend_before_action :validate_session
         end
 


### PR DESCRIPTION
Gets rid of a few FIXME's.

Set has been in Ruby forever, and it supports the few methods already used on the existing arrays (`<<`, `find`, `each`).