### PR TITLE
Updated the generators to allow name spaced models to be passed in.

### DIFF
--- a/lib/generators/sorcery/helpers.rb
+++ b/lib/generators/sorcery/helpers.rb
@@ -12,6 +12,10 @@ module Sorcery
         options[:model] ? options[:model].classify : 'User'
       end
 
+      def tableized_model_class
+        options[:model] ? options[:model].gsub(/::/, '').tableize : 'User'
+      end
+
       def model_path
         @model_path ||= File.join('app', 'models', "#{file_path}.rb")
       end

--- a/lib/generators/sorcery/templates/migration/activity_logging.rb
+++ b/lib/generators/sorcery/templates/migration/activity_logging.rb
@@ -1,10 +1,10 @@
 class SorceryActivityLogging < <%= migration_class_name %>
   def change
-    add_column :<%= model_class_name.tableize %>, :last_login_at,     :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :last_logout_at,    :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :last_activity_at,  :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :last_login_from_ip_address, :string, default: nil
+    add_column :<%= tableized_model_class %>, :last_login_at,     :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :last_logout_at,    :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :last_activity_at,  :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :last_login_from_ip_address, :string, default: nil
 
-    add_index :<%= model_class_name.tableize %>, [:last_logout_at, :last_activity_at]
+    add_index :<%= tableized_model_class %>, [:last_logout_at, :last_activity_at]
   end
 end

--- a/lib/generators/sorcery/templates/migration/brute_force_protection.rb
+++ b/lib/generators/sorcery/templates/migration/brute_force_protection.rb
@@ -1,9 +1,9 @@
 class SorceryBruteForceProtection < <%= migration_class_name %>
   def change
-    add_column :<%= model_class_name.tableize %>, :failed_logins_count, :integer, default: 0
-    add_column :<%= model_class_name.tableize %>, :lock_expires_at, :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :unlock_token, :string, default: nil
+    add_column :<%= tableized_model_class %>, :failed_logins_count, :integer, default: 0
+    add_column :<%= tableized_model_class %>, :lock_expires_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :unlock_token, :string, default: nil
 
-    add_index :<%= model_class_name.tableize %>, :unlock_token
+    add_index :<%= tableized_model_class %>, :unlock_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/core.rb
+++ b/lib/generators/sorcery/templates/migration/core.rb
@@ -1,6 +1,6 @@
 class SorceryCore < <%= migration_class_name %>
   def change
-    create_table :<%= model_class_name.tableize %> do |t|
+    create_table :<%= tableized_model_class %> do |t|
       t.string :email,            null: false
       t.string :crypted_password
       t.string :salt
@@ -8,6 +8,6 @@ class SorceryCore < <%= migration_class_name %>
       t.timestamps                null: false
     end
 
-    add_index :<%= model_class_name.tableize %>, :email, unique: true
+    add_index :<%= tableized_model_class %>, :email, unique: true
   end
 end

--- a/lib/generators/sorcery/templates/migration/external.rb
+++ b/lib/generators/sorcery/templates/migration/external.rb
@@ -1,7 +1,7 @@
 class SorceryExternal < <%= migration_class_name %>
   def change
     create_table :authentications do |t|
-      t.integer :<%= model_class_name.tableize.singularize %>_id, null: false
+      t.integer :<%= tableized_model_class.singularize %>_id, null: false
       t.string :provider, :uid, null: false
 
       t.timestamps              null: false

--- a/lib/generators/sorcery/templates/migration/magic_login.rb
+++ b/lib/generators/sorcery/templates/migration/magic_login.rb
@@ -1,9 +1,9 @@
 class SorceryMagicLogin < <%= migration_class_name %>
   def change
-    add_column :<%= model_class_name.tableize %>, :magic_login_token, :string, default: nil
-    add_column :<%= model_class_name.tableize %>, :magic_login_token_expires_at, :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :magic_login_email_sent_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :magic_login_token, :string, default: nil
+    add_column :<%= tableized_model_class %>, :magic_login_token_expires_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :magic_login_email_sent_at, :datetime, default: nil
 
-    add_index :<%= model_class_name.tableize %>, :magic_login_token
+    add_index :<%= tableized_model_class %>, :magic_login_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/remember_me.rb
+++ b/lib/generators/sorcery/templates/migration/remember_me.rb
@@ -1,8 +1,8 @@
 class SorceryRememberMe < <%= migration_class_name %>
   def change
-    add_column :<%= model_class_name.tableize %>, :remember_me_token, :string, default: nil
-    add_column :<%= model_class_name.tableize %>, :remember_me_token_expires_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :remember_me_token, :string, default: nil
+    add_column :<%= tableized_model_class %>, :remember_me_token_expires_at, :datetime, default: nil
 
-    add_index :<%= model_class_name.tableize %>, :remember_me_token
+    add_index :<%= tableized_model_class %>, :remember_me_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/reset_password.rb
+++ b/lib/generators/sorcery/templates/migration/reset_password.rb
@@ -1,10 +1,10 @@
 class SorceryResetPassword < <%= migration_class_name %>
   def change
-    add_column :<%= model_class_name.tableize %>, :reset_password_token, :string, default: nil
-    add_column :<%= model_class_name.tableize %>, :reset_password_token_expires_at, :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :reset_password_email_sent_at, :datetime, default: nil
-    add_column :<%= model_class_name.tableize %>, :access_count_to_reset_password_page, :integer, default: 0
+    add_column :<%= tableized_model_class %>, :reset_password_token, :string, default: nil
+    add_column :<%= tableized_model_class %>, :reset_password_token_expires_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :reset_password_email_sent_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :access_count_to_reset_password_page, :integer, default: 0
 
-    add_index :<%= model_class_name.tableize %>, :reset_password_token
+    add_index :<%= tableized_model_class %>, :reset_password_token
   end
 end

--- a/lib/generators/sorcery/templates/migration/user_activation.rb
+++ b/lib/generators/sorcery/templates/migration/user_activation.rb
@@ -1,9 +1,9 @@
 class SorceryUserActivation < <%= migration_class_name %>
   def change
-    add_column :<%= model_class_name.tableize %>, :activation_state, :string, default: nil
-    add_column :<%= model_class_name.tableize %>, :activation_token, :string, default: nil
-    add_column :<%= model_class_name.tableize %>, :activation_token_expires_at, :datetime, default: nil
+    add_column :<%= tableized_model_class %>, :activation_state, :string, default: nil
+    add_column :<%= tableized_model_class %>, :activation_token, :string, default: nil
+    add_column :<%= tableized_model_class %>, :activation_token_expires_at, :datetime, default: nil
 
-    add_index :<%= model_class_name.tableize %>, :activation_token
+    add_index :<%= tableized_model_class %>, :activation_token
   end
 end


### PR DESCRIPTION
Example: "ExampleNameSpace::User" parameter which will generate a table migration with "example_name_space_user" as the table name.

It's my first shot at helping out with some open source work, so I hope this is a useful starting contribution!
