### PR TITLE
Add support for Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 2.4.9
   - 2.5.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,8 @@ rvm:
 gemfile:
   - gemfiles/rails_52.gemfile
   - gemfiles/rails_60.gemfile
+
+jobs:
+  exclude:
+  - rvm: 2.4.9
+    gemfile: gemfiles/rails_60.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ rvm:
   - 2.6.5
 
 gemfile:
-  - Gemfile
+  - gemfiles/rails_52.gemfile
+  - gemfiles/rails_60.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'pry'
-gem 'rails', '~> 5.2.0'
+gem 'rails'
 gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.3.6'
+gem 'sqlite3'
 
 gemspec

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 5.2.0'
+gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.3.6'
+
+gemspec path: '..'

--- a/gemfiles/rails_60.gemfile
+++ b/gemfiles/rails_60.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 6.0.0'
+gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.4'
+
+gemspec path: '..'

--- a/spec/rails_app/app/controllers/application_controller.rb
+++ b/spec/rails_app/app/controllers/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < ActionController::Base
+end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -1,6 +1,6 @@
 require 'oauth'
 
-class SorceryController < ActionController::Base
+class SorceryController < ApplicationController
   protect_from_forgery
 
   before_action :require_login_from_http_basic, only: [:test_http_basic_auth]

--- a/spec/support/migration_helper.rb
+++ b/spec/support/migration_helper.rb
@@ -1,7 +1,9 @@
 class MigrationHelper
   class << self
     def migrate(path)
-      if ActiveRecord.version >= Gem::Version.new('5.2.0')
+      if ActiveRecord.version >= Gem::Version.new('6.0.0')
+        ActiveRecord::MigrationContext.new(path, schema_migration).migrate
+      elsif ActiveRecord.version >= Gem::Version.new('5.2.0')
         ActiveRecord::MigrationContext.new(path).migrate
       else
         ActiveRecord::Migrator.migrate(path)
@@ -9,11 +11,19 @@ class MigrationHelper
     end
 
     def rollback(path)
-      if ActiveRecord.version >= Gem::Version.new('5.2.0')
+      if ActiveRecord.version >= Gem::Version.new('6.0.0')
+        ActiveRecord::MigrationContext.new(path, schema_migration).rollback
+      elsif ActiveRecord.version >= Gem::Version.new('5.2.0')
         ActiveRecord::MigrationContext.new(path).rollback
       else
         ActiveRecord::Migrator.rollback(path)
       end
+    end
+
+    private
+
+    def schema_migration
+      ActiveRecord::Base.connection.schema_migration
     end
   end
 end


### PR DESCRIPTION
It adds Rails 6 to TravisCI.

This pull request also contains two changes to fix failing tests with Rails 6.

- Since the usage of `MigrationContext` was changed in rails/rails#36439, adds a branch to MigrationHelper.

- We are loading 'rails/all' in our test code, it implicitly load action_text from Rails 6. ActionText requires ApplicationController, adds it.
  - ref: https://github.com/rails/rails/blob/v6.0.3/actiontext/lib/action_text/engine.rb#L50

