### PR TITLE
Fix failing isolated tests

### DIFF
--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -116,11 +116,20 @@ describe SorceryController, active_record: true, type: :controller do
     end
 
     context 'when callback_url begin with http://' do
+      before do
+        sorcery_controller_external_property_set(:facebook, :callback_url, '/oauth/twitter/callback')
+        sorcery_controller_external_property_set(:facebook, :api_version, 'v2.2')
+      end
+
       it 'login_at redirects correctly' do
         create_new_user
         get :login_at_test_facebook
         expect(response).to be_a_redirect
         expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state")
+      end
+
+      after do
+        sorcery_controller_external_property_set(:facebook, :callback_url, 'http://blabla.com')
       end
     end
 

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -84,10 +84,16 @@ describe SorceryController, type: :controller do
     end
 
     context 'when callback_url begin with http://' do
+      before do
+        sorcery_controller_external_property_set(:twitter, :callback_url, '/oauth/twitter/callback')
+      end
       it 'login_at redirects correctly', pending: true do
         get :login_at_test
         expect(response).to be_a_redirect
         expect(response).to redirect_to('http://myapi.com/oauth/authorize?oauth_callback=http%3A%2F%2Fblabla.com&oauth_token=')
+      end
+      after do
+        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
       end
     end
 


### PR DESCRIPTION
These tests will fail when run individually, so I fix them.

```console
$ bundle exec rspec spec/controllers/controller_oauth2_spec.rb:118

Failures:

  1) SorceryController with OAuth features when callback_url begin with http:// login_at redirects correctly
     Failure/Error: expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state")

       Expected response to be a redirect to <https://www.facebook.com/v2.2/dialog/oauth?client_id=eYVNBjBDi33aa9GkA3w&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state> but was a redirect to <https://www.facebook.com/dialog/oauth?client_id=eYVNBjBDi33aa9GkA3w&display=page&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=email&state>.
       Expected "https://www.facebook.com/v2.2/dialog/oauth?client_id=eYVNBjBDi33aa9GkA3w&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state" to be === "https://www.facebook.com/dialog/oauth?client_id=eYVNBjBDi33aa9GkA3w&display=page&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=email&state".
     # ./spec/controllers/controller_oauth2_spec.rb:123:in `block (4 levels) in <top (required)>'
```

```console
$ bundle exec rspec spec/controllers/controller_oauth_spec.rb:86

Failures:

  1) SorceryController SorceryController 'using external API to login' when callback_url begin with http:// login_at redirects correctly FIXED
     Expected pending 'No reason given' to fail. No error was raised.
     # ./spec/controllers/controller_oauth_spec.rb:87
```