### PR TITLE
Support overwriting config per controller and multi-class logins

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -26,6 +26,13 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.cookie_domain =
 
+  # Set the session key to login.
+  # If you want to use a dynamic session key, specify a Proc.
+  # (e.g. `->(c) { "sorcery_#{c.user_class.name.underscore}_id".to_sym }`)
+  # Default: `:user_id`
+  #
+  # config.login_session_key =
+
   # Allow the remember_me cookie to be set through AJAX
   # Default: `true`
   #

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -113,7 +113,7 @@ module Sorcery
       # @param [<User-Model>] user the user instance.
       # @return - do not depend on the return value.
       def auto_login(user, _should_remember = false)
-        session[:user_id] = user.id.to_s
+        session[sorcery_config.session_key] = user.id.to_s
         @current_user = user
       end
 
@@ -140,8 +140,8 @@ module Sorcery
       end
 
       def login_from_session
-        @current_user = if session[:user_id]
-                          user_class.sorcery_adapter.find_by_id(session[:user_id])
+        @current_user = if session[sorcery_config.session_key]
+                          user_class.sorcery_adapter.find_by_id(session[sorcery_config.session_key])
                         end
       end
 

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -14,7 +14,6 @@ module Sorcery
           # rubocop:enable Lint/HandleExceptions
         end
       end
-      Config.update!
       Config.configure!
     end
 
@@ -128,7 +127,7 @@ module Sorcery
       protected
 
       def sorcery_config
-        @sorcery_config ||= Config
+        @sorcery_config ||= Config.instance.dup
       end
 
       # Tries all available sources (methods) until one doesn't return false.

--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -1,39 +1,36 @@
 module Sorcery
   module Controller
     module Config
-      class << self
-        attr_accessor :submodules
+      DEFAULTS = {
         # what class to use as the user class.
-        attr_accessor :user_class
+        :user_class                           => nil,
+        :submodules                           => [],
         # what controller action to call for non-authenticated users.
-        attr_accessor :not_authenticated_action
+        :not_authenticated_action             => :not_authenticated,
+        :login_sources                        => Set.new,
+        :after_login                          => Set.new,
+        :after_failed_login                   => Set.new,
+        :before_logout                        => Set.new,
+        :after_logout                         => Set.new,
+        :after_remember_me                    => Set.new,
         # when a non logged in user tries to enter a page that requires login,
         # save the URL he wanted to reach, and send him there after login.
-        attr_accessor :save_return_to_url
+        :save_return_to_url                   => true,
         # set domain option for cookies
-        attr_accessor :cookie_domain
+        :cookie_domain                        => nil
+      }.freeze
+      private_constant :DEFAULTS
 
-        attr_accessor :login_sources
-        attr_accessor :after_login
-        attr_accessor :after_failed_login
-        attr_accessor :before_logout
-        attr_accessor :after_logout
-        attr_accessor :after_remember_me
+      class << self
+        def add_defaults(defaults)
+          singleton_class.attr_accessor(*defaults.keys)
+          @defaults.merge!(
+            defaults.transform_keys { |key| "@#{key}".to_sym }
+          )
+        end
 
         def init!
-          @defaults = {
-            :@user_class                           => nil,
-            :@submodules                           => [],
-            :@not_authenticated_action             => :not_authenticated,
-            :@login_sources                        => Set.new,
-            :@after_login                          => Set.new,
-            :@after_failed_login                   => Set.new,
-            :@before_logout                        => Set.new,
-            :@after_logout                         => Set.new,
-            :@after_remember_me                    => Set.new,
-            :@save_return_to_url                   => true,
-            :@cookie_domain                        => nil
-          }
+          @defaults = DEFAULTS.map { |k, v| ["@#{k}".to_sym, v.dup] }.to_h
         end
 
         # Resets all configuration options to their default values.
@@ -63,6 +60,7 @@ module Sorcery
       end
 
       init!
+      add_defaults(DEFAULTS)
       reset!
     end
   end

--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -17,7 +17,8 @@ module Sorcery
         # save the URL he wanted to reach, and send him there after login.
         :save_return_to_url                   => true,
         # set domain option for cookies
-        :cookie_domain                        => nil
+        :cookie_domain                        => nil,
+        :login_session_key                    => :user_id
       }.freeze
       private_constant :DEFAULTS
 
@@ -90,6 +91,14 @@ module Sorcery
 
       def dup
         self.class.new(attributes)
+      end
+
+      def session_key
+        if login_session_key.is_a?(Proc)
+          login_session_key.call(self)
+        else
+          login_session_key
+        end
       end
 
       private def attributes

--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -14,22 +14,12 @@ module Sorcery
       module ActivityLogging
         def self.included(base)
           base.send(:include, InstanceMethods)
-          Config.module_eval do
-            class << self
-              attr_accessor :register_login_time
-              attr_accessor :register_logout_time
-              attr_accessor :register_last_activity_time
-              attr_accessor :register_last_ip_address
-
-              def merge_activity_logging_defaults!
-                @defaults.merge!(:@register_login_time         => true,
-                                 :@register_logout_time        => true,
-                                 :@register_last_activity_time => true,
-                                 :@register_last_ip_address    => true)
-              end
-            end
-            merge_activity_logging_defaults!
-          end
+          Config.add_defaults(
+            :register_login_time         => true,
+            :register_logout_time        => true,
+            :register_last_activity_time => true,
+            :register_last_ip_address    => true
+          )
 
           Config.after_login << :register_login_time_to_db
           Config.after_login << :register_last_ip_address

--- a/lib/sorcery/controller/submodules/activity_logging.rb
+++ b/lib/sorcery/controller/submodules/activity_logging.rb
@@ -34,7 +34,7 @@ module Sorcery
           # registers last login time on every login.
           # This runs as a hook just after a successful login.
           def register_login_time_to_db(user, _credentials)
-            return unless Config.register_login_time
+            return unless sorcery_config.register_login_time
 
             user.set_last_login_at(Time.now.in_time_zone)
           end
@@ -42,7 +42,7 @@ module Sorcery
           # registers last logout time on every logout.
           # This runs as a hook just before a logout.
           def register_logout_time_to_db
-            return unless Config.register_logout_time
+            return unless sorcery_config.register_logout_time
 
             current_user.set_last_logout_at(Time.now.in_time_zone)
           end
@@ -50,7 +50,7 @@ module Sorcery
           # Updates last activity time on every request.
           # The only exception is logout - we do not update activity on logout
           def register_last_activity_time_to_db
-            return unless Config.register_last_activity_time
+            return unless sorcery_config.register_last_activity_time
             return unless logged_in?
 
             current_user.set_last_activity_at(Time.now.in_time_zone)
@@ -59,7 +59,7 @@ module Sorcery
           # Updates IP address on every login.
           # This runs as a hook just after a successful login.
           def register_last_ip_address(_user, _credentials)
-            return unless Config.register_last_ip_address
+            return unless sorcery_config.register_last_ip_address
 
             current_user.set_last_ip_address(request.remote_ip)
           end

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -54,9 +54,9 @@ module Sorcery
 
           # save the singleton ProviderClient instance into @provider
           def sorcery_get_provider(provider_name)
-            return unless Config.external_providers.include?(provider_name.to_sym)
+            return unless sorcery_config.external_providers.include?(provider_name.to_sym)
 
-            Config.send(provider_name.to_sym)
+            sorcery_config.send(provider_name.to_sym)
           end
 
           # get the login URL from the provider, if applicable.  Returns nil if the provider

--- a/lib/sorcery/controller/submodules/http_basic_auth.rb
+++ b/lib/sorcery/controller/submodules/http_basic_auth.rb
@@ -50,14 +50,14 @@ module Sorcery
             if defined?(ActionController::Base)
               current_controller = self.class
               while current_controller != ActionController::Base
-                result = Config.controller_to_realm_map[current_controller.controller_name]
+                result = sorcery_config.controller_to_realm_map[current_controller.controller_name]
                 return result if result
 
                 current_controller = current_controller.superclass
               end
               nil
             else
-              Config.controller_to_realm_map['application']
+              sorcery_config.controller_to_realm_map['application']
             end
           end
         end

--- a/lib/sorcery/controller/submodules/http_basic_auth.rb
+++ b/lib/sorcery/controller/submodules/http_basic_auth.rb
@@ -9,16 +9,10 @@ module Sorcery
       module HttpBasicAuth
         def self.included(base)
           base.send(:include, InstanceMethods)
-          Config.module_eval do
-            class << self
-              attr_accessor :controller_to_realm_map # What realm to display for which controller name.
-
-              def merge_http_basic_auth_defaults!
-                @defaults.merge!(:@controller_to_realm_map => { 'application' => 'Application' })
-              end
-            end
-            merge_http_basic_auth_defaults!
-          end
+          Config.add_defaults(
+            # What realm to display for which controller name.
+            :controller_to_realm_map => { 'application' => 'Application' }
+          )
 
           Config.login_sources << :login_from_basic_auth
         end

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -38,7 +38,7 @@ module Sorcery
           # Override.
           # logins a user instance, and optionally remembers him.
           def auto_login(user, should_remember = false)
-            session[:user_id] = user.id.to_s
+            session[sorcery_config.session_key] = user.id.to_s
             @current_user = user
             remember_me! if should_remember
           end
@@ -52,7 +52,7 @@ module Sorcery
             user = cookies.signed[:remember_me_token] && user_class.sorcery_adapter.find_by_remember_me_token(cookies.signed[:remember_me_token]) if defined? cookies
             if user && user.has_remember_me_token?
               set_remember_me_cookie!(user)
-              session[:user_id] = user.id.to_s
+              session[sorcery_config.session_key] = user.id.to_s
               after_remember_me!(user)
               @current_user = user
             else

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -26,13 +26,13 @@ module Sorcery
           # Clears the cookie, and depending on the value of remember_me_token_persist_globally, may clear the token value.
           def forget_me!
             current_user.forget_me!
-            cookies.delete(:remember_me_token, domain: Config.cookie_domain)
+            cookies.delete(:remember_me_token, domain: sorcery_config.cookie_domain)
           end
 
           # Clears the cookie, and clears the token value.
           def force_forget_me!
             current_user.force_forget_me!
-            cookies.delete(:remember_me_token, domain: Config.cookie_domain)
+            cookies.delete(:remember_me_token, domain: sorcery_config.cookie_domain)
           end
 
           # Override.
@@ -64,8 +64,8 @@ module Sorcery
             cookies.signed[:remember_me_token] = {
               value: user.send(user.sorcery_config.remember_me_token_attribute_name),
               expires: user.send(user.sorcery_config.remember_me_token_expires_at_attribute_name),
-              httponly: Config.remember_me_httponly,
-              domain: Config.cookie_domain
+              httponly: sorcery_config.remember_me_httponly,
+              domain: sorcery_config.cookie_domain
             }
           end
         end

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -8,15 +8,9 @@ module Sorcery
       module RememberMe
         def self.included(base)
           base.send(:include, InstanceMethods)
-          Config.module_eval do
-            class << self
-              attr_accessor :remember_me_httponly
-              def merge_remember_me_defaults!
-                @defaults.merge!(:@remember_me_httponly => true)
-              end
-            end
-            merge_remember_me_defaults!
-          end
+          Config.add_defaults(
+            :remember_me_httponly => true
+          )
 
           Config.login_sources << :login_from_cookie
           Config.before_logout << :forget_me!

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -23,7 +23,7 @@ module Sorcery
 
         module InstanceMethods
           def invalidate_active_sessions!
-            return unless Config.session_timeout_invalidate_active_sessions_enabled
+            return unless sorcery_config.session_timeout_invalidate_active_sessions_enabled
             return unless current_user.present?
 
             current_user.send(:invalidate_sessions_before=, Time.now.in_time_zone)
@@ -41,7 +41,7 @@ module Sorcery
           # Checks if session timeout was reached and expires the current session if so.
           # To be used as a before_action, before require_login
           def validate_session
-            session_to_use = Config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
+            session_to_use = sorcery_config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
             if (session_to_use && sorcery_session_expired?(session_to_use.to_time)) || sorcery_session_invalidated?
               reset_sorcery_session
               remove_instance_variable :@current_user if defined? @current_user
@@ -51,12 +51,12 @@ module Sorcery
           end
 
           def sorcery_session_expired?(time)
-            Time.now.in_time_zone - time > Config.session_timeout
+            Time.now.in_time_zone - time > sorcery_config.session_timeout
           end
 
           # Use login time if present, otherwise use last action time.
           def sorcery_session_invalidated?
-            return false unless Config.session_timeout_invalidate_active_sessions_enabled
+            return false unless sorcery_config.session_timeout_invalidate_active_sessions_enabled
             return false unless current_user.present? && current_user.try(:invalidate_sessions_before).present?
 
             time = session[:login_time] || session[:last_action_time] || Time.now.in_time_zone

--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -6,23 +6,14 @@ module Sorcery
       module SessionTimeout
         def self.included(base)
           base.send(:include, InstanceMethods)
-          Config.module_eval do
-            class << self
-              # how long in seconds to keep the session alive.
-              attr_accessor :session_timeout
-              # use the last action as the beginning of session timeout.
-              attr_accessor :session_timeout_from_last_action
-              # allow users to invalidate active sessions
-              attr_accessor :session_timeout_invalidate_active_sessions_enabled
-
-              def merge_session_timeout_defaults!
-                @defaults.merge!(:@session_timeout                                    => 3600, # 1.hour
-                                 :@session_timeout_from_last_action                   => false,
-                                 :@session_timeout_invalidate_active_sessions_enabled => false)
-              end
-            end
-            merge_session_timeout_defaults!
-          end
+          Config.add_defaults(
+            # how long in seconds to keep the session alive.
+            :session_timeout                                    => 3600, # 1.hour
+            # use the last action as the beginning of session timeout.
+            :session_timeout_from_last_action                   => false,
+            # allow users to invalidate active sessions
+            :session_timeout_invalidate_active_sessions_enabled => false
+          )
 
           Config.after_login << :register_login_time
           Config.after_remember_me << :register_login_time

--- a/lib/sorcery/test_helpers/internal/rails.rb
+++ b/lib/sorcery/test_helpers/internal/rails.rb
@@ -15,7 +15,6 @@ module Sorcery
 
           # return to no-module configuration
           ::Sorcery::Controller::Config.init!
-          ::Sorcery::Controller::Config.reset!
 
           # remove all plugin before_actions so they won't fail other tests.
           # I don't like this way, but I didn't find another.

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -318,6 +318,7 @@ describe SorceryController, active_record: true, type: :controller do
 
     before(:all) do
       sorcery_reload!(%i[activity_logging external])
+      set_external_property
     end
 
     %w[facebook github google liveid vk salesforce slack discord].each do |provider|
@@ -355,6 +356,7 @@ describe SorceryController, active_record: true, type: :controller do
   describe 'OAuth with session timeout features' do
     before(:all) do
       sorcery_reload!(%i[session_timeout external])
+      set_external_property
     end
 
     let(:user) { double('user', id: 42) }

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -116,11 +116,20 @@ describe SorceryController, active_record: true, type: :controller do
     end
 
     context 'when callback_url begin with http://' do
+      before do
+        sorcery_controller_external_property_set(:facebook, :callback_url, '/oauth/twitter/callback')
+        sorcery_controller_external_property_set(:facebook, :api_version, 'v2.2')
+      end
+
       it 'login_at redirects correctly' do
         create_new_user
         get :login_at_test_facebook
         expect(response).to be_a_redirect
         expect(response).to redirect_to("https://www.facebook.com/v2.2/dialog/oauth?client_id=#{::Sorcery::Controller::Config.facebook.key}&display=page&redirect_uri=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&response_type=code&scope=email&state")
+      end
+
+      after do
+        sorcery_controller_external_property_set(:facebook, :callback_url, 'http://blabla.com')
       end
     end
 

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -84,10 +84,16 @@ describe SorceryController, type: :controller do
     end
 
     context 'when callback_url begin with http://' do
+      before do
+        sorcery_controller_external_property_set(:twitter, :callback_url, '/oauth/twitter/callback')
+      end
       it 'login_at redirects correctly', pending: true do
         get :login_at_test
         expect(response).to be_a_redirect
         expect(response).to redirect_to('http://myapi.com/oauth/authorize?oauth_callback=http%3A%2F%2Fblabla.com&oauth_token=')
+      end
+      after do
+        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
       end
     end
 

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -190,6 +190,11 @@ describe SorceryController, type: :controller do
 
     context 'when twitter' do
       before(:each) do
+        sorcery_controller_property_set(:external_providers, %i[twitter])
+        sorcery_controller_external_property_set(:twitter, :key, 'eYVNBjBDi33aa9GkA3w')
+        sorcery_controller_external_property_set(:twitter, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
+        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
+
         sorcery_controller_property_set(:register_login_time, true)
         sorcery_controller_property_set(:register_logout_time, false)
         sorcery_controller_property_set(:register_last_activity_time, false)
@@ -236,6 +241,11 @@ describe SorceryController, type: :controller do
 
     context 'when twitter' do
       before(:each) do
+        sorcery_controller_property_set(:external_providers, %i[twitter])
+        sorcery_controller_external_property_set(:twitter, :key, 'eYVNBjBDi33aa9GkA3w')
+        sorcery_controller_external_property_set(:twitter, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
+        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
+
         sorcery_model_property_set(:authentications_class, Authentication)
         sorcery_controller_property_set(:session_timeout, 0.5)
         stub_all_oauth_requests!

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -83,6 +83,24 @@ describe SorceryController, type: :controller do
           expect(session[:user_id]).to be_nil
         end
       end
+
+      context "when using Operator as user_class" do
+        let(:operator) { double('operator', id: 42) }
+
+        before do
+          Operator.authenticates_with_sorcery!
+          expect(Operator).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(operator, nil) }
+          get :test_login_for_operator, params: { email: 'bla@bla.com', password: 'secret' }
+        end
+
+        it 'assigns operator to @user variable' do
+          expect(assigns[:user]).to eq operator
+        end
+
+        it 'writes operator id in session' do
+          expect(session[:sorcery_operator_id]).to eq operator.id.to_s
+        end
+      end
     end
 
     describe '#logout' do

--- a/spec/rails_app/app/active_record/operator.rb
+++ b/spec/rails_app/app/active_record/operator.rb
@@ -1,0 +1,2 @@
+class Operator < ActiveRecord::Base
+end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -28,6 +28,15 @@ class SorceryController < ApplicationController
     head :ok
   end
 
+  def test_login_for_operator
+    sorcery_config.user_class = Operator
+    sorcery_config.login_session_key = ->(c) { "sorcery_#{c.user_class.name.downcase}_id".to_sym }
+
+    @user = login(params[:email], params[:password])
+    head :ok
+  end
+
+
   def test_auto_login
     @user = User.first
     auto_login(@user)

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -3,6 +3,7 @@ AppRoot::Application.routes.draw do
 
   controller :sorcery do
     get :test_login
+    get :test_login_for_operator
     get :test_logout
     get :some_action
     post :test_return_to


### PR DESCRIPTION
This pull request is intended to support logins for multiple roles, such as User and Admin.

First, change the configuration to use an instance instead of Module to allow overwriting it per controllers.
In a controller, you can access it with `sorcery_config`.

Next, add `login_session_key` to the configuration so that we can change the session key from `:user_id`.
It also supports Proc to be able to change the session key automatically according to the `user_class`.

These changes allow you to maintain multiple sessions.

```ruby
class Admins::BaseController < ApplicationController
  before_action :set_admin_to_sorcery_config

  private

  def set_admin_to_sorcery_config
    sorcery_config.user_class = Admin
    sorcery_config.login_session_key = :admin_id
  end
end
```

## NOTE

I'd like to get opinions from Sorcery maintainers, as being able to override config per controllers is the notable design change.
Overriding the config is a big change, so we might to separate pull requests.