### PR TITLE
Support line login v2.1

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -222,6 +222,9 @@ Rails.application.config.sorcery.configure do |config|
   # config.line.key = ""
   # config.line.secret = ""
   # config.line.callback_url = "http://mydomain.com:3000/oauth/callback?provider=line"
+  # config.line.scope = "profile"
+  # config.line.bot_prompt = "normal"
+  # config.line.user_info_mapping = {name: 'displayName'}
 
   # For infromation about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2

--- a/lib/sorcery/providers/line.rb
+++ b/lib/sorcery/providers/line.rb
@@ -9,15 +9,16 @@ module Sorcery
     class Line < Base
       include Protocols::Oauth2
 
-      attr_accessor :token_url, :user_info_path, :auth_path
+      attr_accessor :token_url, :user_info_path, :auth_path, :scope, :bot_prompt
 
       def initialize
         super
 
         @site           = 'https://access.line.me'
         @user_info_path = 'https://api.line.me/v2/profile'
-        @token_url      = 'https://api.line.me/v2/oauth/accessToken'
-        @auth_path      = 'dialog/oauth/weblogin'
+        @token_url      = 'https://api.line.me/oauth2/v2.1/token'
+        @auth_path      = 'oauth2/v2.1/authorize'
+        @scope          = 'profile'
       end
 
       def get_user_hash(access_token)
@@ -34,13 +35,28 @@ module Sorcery
         @state = SecureRandom.hex(16)
         authorize_url(authorize_url: auth_path)
       end
+
+      # overrides oauth2#authorize_url to add bot_prompt query.
+      def authorize_url(options = {})
+        options.merge!({
+          connection_opts: { params: { bot_prompt: bot_prompt } }
+        }) if bot_prompt.present?
+
+        super(options)
+      end
+
       # tries to login the user from access token
       def process_callback(params, _session)
         args = {}.tap do |a|
           a[:code] = params[:code] if params[:code]
         end
 
-        get_access_token(args, token_url: token_url, token_method: :post)
+        get_access_token(
+          args,
+          token_url: token_url,
+          token_method: :post,
+          grant_type: 'authorization_code'
+        )
       end
     end
   end


### PR DESCRIPTION


Support for LINE login v2.1. ref: https://github.com/Sorcery/sorcery/pull/80  
doc -> https://developers.line.biz/en/docs/line-login/integrate-line-login/#login-flow

I proposed because I need bot_prompt function. It's enable you to add [LINE Bot](https://developers.line.biz/en/docs/messaging-api/overview/) when login with line.

### What is LINE?
https://github.com/Sorcery/sorcery/pull/80#issuecomment-327351210

> LINE is the most popular messaging application in Japan. But, it is not popular outside Japan.
LINE is similar to WhatsApp or Facebook Messenger.
About 70% of Japanese are using it, and it is used for 500 million people all over the world.

https://en.wikipedia.org/wiki/Line_(software)