### PR TITLE
Add back changes that fix deprecation warning related to autoloading in Rails 6

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -14,8 +14,6 @@ module Sorcery
           # rubocop:enable Lint/HandleExceptions
         end
       end
-      Config.update!
-      Config.configure!
     end
 
     module InstanceMethods

--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -54,11 +54,8 @@ module Sorcery
         end
 
         def configure(&blk)
-          @configure_blk = blk
-        end
-
-        def configure!
-          @configure_blk.call(self) if @configure_blk
+          update!
+          blk.call(self) if blk
         end
       end
 

--- a/lib/sorcery/engine.rb
+++ b/lib/sorcery/engine.rb
@@ -9,18 +9,12 @@ module Sorcery
 
     # TODO: Should this include a modified version of the helper methods?
     initializer 'extend Controller with sorcery' do
-      # FIXME: on_load is needed to fix Rails 6 deprecations, but it breaks
-      #        applications due to undefined method errors.
-      # ActiveSupport.on_load(:action_controller_api) do
-      if defined?(ActionController::API)
-        ActionController::API.send(:include, Sorcery::Controller)
+      ActiveSupport.on_load(:action_controller_api) do
+        ActionController::API.include(Sorcery::Controller)
       end
 
-      # FIXME: on_load is needed to fix Rails 6 deprecations, but it breaks
-      #        applications due to undefined method errors.
-      # ActiveSupport.on_load(:action_controller_base) do
-      if defined?(ActionController::Base)
-        ActionController::Base.send(:include, Sorcery::Controller)
+      ActiveSupport.on_load(:action_controller_base) do
+        ActionController::Base.include(Sorcery::Controller)
         ActionController::Base.helper_method :current_user
         ActionController::Base.helper_method :logged_in?
       end

--- a/spec/controllers/controller_activity_logging_spec.rb
+++ b/spec/controllers/controller_activity_logging_spec.rb
@@ -45,6 +45,8 @@ describe SorceryController, type: :controller do
       login_user(user)
       now = Time.now.in_time_zone
       Timecop.freeze(now)
+
+      sorcery_controller_property_set(:register_logout_time, true)
       expect(user).to receive(:set_last_logout_at).with(be_within(0.1).of(now))
 
       logout_user


### PR DESCRIPTION
This PR introduces the following changes:

1. Add back changes from #209 that fix deprecation warning "Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper."

2. Call sorcery config block where it is defined to fix "To use reset_password submodule, you must define a mailer" error. This error started to occur after adding changes from #209 when calling the user model in the rails development console.