### PR TITLE
Fix `require 'sorcery'` error without rails

### DIFF
--- a/lib/sorcery/test_helpers/internal/rails.rb
+++ b/lib/sorcery/test_helpers/internal/rails.rb
@@ -63,7 +63,7 @@ module Sorcery
           subject.instance_variable_set(:@current_user, nil)
         end
 
-        if ::Rails.version < '5.0.0'
+        if defined?(::Rails) && ::Rails.version < '5.0.0'
           %w[get post put].each do |method|
             define_method(method) do |action, options = {}|
               super action, options[:params] || {}, options[:session]

--- a/spec/require_without_rails_spec.rb
+++ b/spec/require_without_rails_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'open3'
+
+describe 'require sorcery without rails' do
+  it 'should not raise any error' do
+    Open3.popen3("ruby") do |stdin, stdout, stderr, wait_thr|
+      stdin.puts(<<-RUBY)
+        require 'bundler/inline'
+        gemfile do
+          source 'https://rubygems.org'
+          gem 'sorcery', path: '.'
+        end
+      RUBY
+      stdin.close
+
+      wait_thr.join
+
+      expect(stdout.read).to eq ""
+      expect(stderr.read).to eq ""
+    end
+  end
+end


### PR DESCRIPTION
Since Sorcery 0.10, it can't be required without Rails.

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'sorcery', '< 0.10'
end

# No error
```

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'sorcery', '>= 0.10'
end

#Traceback (most recent call last):
#        19: from hi.rb:2:in `<main>'
#        18: from /usr/local/lib/ruby/2.7.0/bundler/inline.rb:54:in `gemfile'
#        17: from /usr/local/lib/ruby/2.7.0/bundler/settings.rb:124:in `temporary'
#        16: from /usr/local/lib/ruby/2.7.0/bundler/inline.rb:70:in `block in gemfile'
#        15: from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:58:in `require'
#        14: from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:58:in `each'
#        13: from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:69:in `block in require'
#        12: from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:69:in `each'
#        11: from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:74:in `block (2 levels) in require'
#        10: from /usr/local/lib/ruby/2.7.0/bundler/runtime.rb:74:in `require'
#         9: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery.rb:3:in `<top (required)>'
#         8: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery.rb:54:in `<module:Sorcery>'
#         7: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery.rb:63:in `<module:TestHelpers>'
#         6: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery.rb:64:in `<module:Internal>'
#         5: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery.rb:64:in `require'
#         4: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery/test_helpers/internal/rails.rb:1:in `<top (required)>'
#         3: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery/test_helpers/internal/rails.rb:2:in `<module:Sorcery>'
#         2: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery/test_helpers/internal/rails.rb:3:in `<module:TestHelpers>'
#         1: from /usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery/test_helpers/internal/rails.rb:4:in `<module:Internal>'
#/usr/local/bundle/gems/sorcery-0.15.0/lib/sorcery/test_helpers/internal/rails.rb:66:in `<module:Rails>': uninitialized constant Rails (NameError)
```

In most case, Sorcery is used with Rails but I think actually this gem doesn't need Rails
because there's `defined?` check:

https://github.com/Sorcery/sorcery/blob/a02c1247642357129ea739354c22978a06fccaa9/lib/sorcery.rb#L96

---

Please ensure your pull request includes the following:

- [x] Description of changes
- [x] Update to CHANGELOG.md with short description and link to pull request
- [x] Changes have related RSpec tests that ensure functionality does not break
