### PR TITLE
Removed the link to inch-ci badge in README.md because it wad dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Gem Downloads](https://img.shields.io/gem/dt/sorcery.svg)](https://rubygems.org/gems/sorcery)
 [![Build Status](https://travis-ci.org/Sorcery/sorcery.svg?branch=master)](https://travis-ci.org/Sorcery/sorcery)
 [![Code Climate](https://codeclimate.com/github/Sorcery/sorcery.svg)](https://codeclimate.com/github/Sorcery/sorcery)
-[![Inline docs](http://inch-ci.org/github/Sorcery/sorcery.svg?branch=master)](http://inch-ci.org/github/Sorcery/sorcery)
 [![Join the chat at https://gitter.im/Sorcery/sorcery](https://badges.gitter.im/join_chat.svg)](https://gitter.im/Sorcery/sorcery?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Magical Authentication for Rails. Supports ActiveRecord, DataMapper, Mongoid and MongoMapper.


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/21003135/109155301-bd5ffa80-77b2-11eb-9f9d-2413442b0bd9.png)

The link to the inch-ci badge in README.md because it was dead.

- Link: http://inch-ci.org/github/Sorcery/sorcery.svg?branch=master

It seems that `inch-ci.org` is not working, and cannot access the site from the following URL.

- Main site: https://inch-ci.org/

The badge was not showing up in README.md for these reasons, so I removed it to improve the documentation.

Please ensure your pull request includes the following:

- [x] Description of changes
- [ ] Update to CHANGELOG.md with short description and link to pull request
- [x] Changes have related RSpec tests that ensure functionality does not break
