### PR TITLE
Fixed default table name in migration file

### DIFF
--- a/lib/generators/sorcery/helpers.rb
+++ b/lib/generators/sorcery/helpers.rb
@@ -13,7 +13,7 @@ module Sorcery
       end
 
       def tableized_model_class
-        options[:model] ? options[:model].gsub(/::/, '').tableize : 'User'
+        options[:model] ? options[:model].gsub(/::/, '').tableize : 'users'
       end
 
       def model_path


### PR DESCRIPTION
The generated result of `bin/rails g sorcery:install` command is incorrect.

Current generated table name is `User`, but correct table name is `users`.

Current generated result

```ruby
class SorceryCore < ActiveRecord::Migration[6.1]
  def change
    create_table :User do |t|
      t.string :email,            null: false
      t.string :crypted_password
      t.string :salt

      t.timestamps                null: false
    end

    add_index :User, :email, unique: true
  end
end
```

Generated result after modification

```ruby
class SorceryCore < ActiveRecord::Migration[6.1]
  def change
    create_table :users do |t|
      t.string :email,            null: false
      t.string :crypted_password
      t.string :salt

      t.timestamps                null: false
    end

    add_index :users, :email, unique: true
  end
end
```

