### PR TITLE
Update phrasing in Philosophy statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Sorcery is a stripped-down, bare-bones authentication library, with which you ca
 
 - Less is more - less than 20 public methods to remember for the entire feature-set make the lib easy to 'get'.
 - No built-in or generated code - use the library's methods inside *your own* MVC structures, and don't fight to fix someone else's.
-- Magic yes, Voodoo no - the lib should be easy to hack for most developers.
+- Approachable and Accessible - the lib should be easy to hack for most developers.
 - Configuration over Confusion - Centralized (1 file), Simple & short configuration as possible, not drowning in syntactic sugar.
 - Keep MVC cleanly separated - DB is for models, sessions are for controllers. Models stay unaware of sessions.
 


### PR DESCRIPTION
Change the philosophy statement so that its heading more clearly relates to the description.

For context, it wasn't clear to me what exactly the "Magic vs Voodoo" comment was trying to say, but it definitely did not communicate to me that the lib would be easy to work on. In the worst reading, I think the comment is unnecessarily disparaging of a real religion and spiritual practice of African origin. The change in this PR is a suggestion that I think communicates the intent more clearly based on the contents of the rest of the line, but if a different change resonates better with your intent y'all are probably the experts on that.

Thanks for your consideration!

Please ensure your pull request includes the following:

- [x] Description of changes
- [ ] Update to CHANGELOG.md with short description and link to pull request
- [X] Changes have related RSpec tests that ensure functionality does not break
