### PR TITLE
Avoid Slack users.identity lookup if access_token contains user info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Inline core migration index definition [#281](https://github.com/Sorcery/sorcery/pull/281)
 * Fix MongoID adapter breaking on save [#284](https://github.com/Sorcery/sorcery/pull/284)
 * Don't pass token to Slack in query params. Prevents 'invalid_auth' error [#287](https://github.com/Sorcery/sorcery/pull/287)
+* Avoid Slack users.identity lookup if access_token contains user info [#288](https://github.com/Sorcery/sorcery/pull/288)
 
 ## 0.16.1
 

--- a/lib/sorcery/providers/slack.rb
+++ b/lib/sorcery/providers/slack.rb
@@ -18,11 +18,9 @@ module Sorcery
       end
 
       def get_user_hash(access_token)
-        response = access_token.get(user_info_path)
         auth_hash(access_token).tap do |h|
-          h[:user_info] = JSON.parse(response.body)
-          h[:user_info]['email'] = h[:user_info]['user']['email']
-          h[:uid] = h[:user_info]['user']['id']
+          h[:user_info] = fetch_user_info(access_token)['user']
+          h[:uid] = h[:user_info]['id']
         end
       end
 
@@ -39,6 +37,20 @@ module Sorcery
         end
 
         get_access_token(args, token_url: token_url, token_method: :post)
+      end
+
+      private
+
+      def fetch_user_info(access_token)
+        return access_token if user_info_present?(access_token)
+
+        JSON.parse(access_token.get(user_info_path).body)
+      end
+
+      def user_info_present?(access_token)
+        access_token['user'].present? &&
+          access_token['user']['id'].present? &&
+          access_token['user']['email'].present?
       end
     end
   end


### PR DESCRIPTION
While testing against various Slack workspaces, I noticed that:
(1) The email and UID of the user is provided in the initial OAuth response so there is no need to call `slack.com/api/users.identity` here https://github.com/Sorcery/sorcery/blob/master/lib/sorcery/providers/slack.rb#L21. The needed info is contained in the `access_token` hash, which should probably be renamed to `access_hash` or `access_data` as it is more than a token, at least when authenticating with Slack.
(2) In some instances, Slack will respond with `{ ok: false, error: 'invalid_auth' }` when requesting user info via `slack.com/api/users.identity`. According to https://api.slack.com/methods/users.identity, this could be due to a generic auth error or restricted IP situation. In either case, the resulting error is not handled gracefully by Sorcery:

```
NoMethodError: undefined method `[]' for nil:NilClass
/gems/sorcery-0.16.1/lib/sorcery/providers/slack.rb:24:in `block in get_user_hash'
```
There is no check in the Slack Provider to see if `ok` is `true` (against the recommendation of Slack docs), and tries to access the JSON returned (`h[:user_info]['email'] = h[:user_info]['user']['email']`), which raises the `NoMethodError` above.

This PR addresses (1) directly and (2) indirectly, since the only instances I found where (2) occurred were instances where (1) was true. The proper solution may be removing the check for `slack.com/api/users.identity` altogether as it may be fully redundant. It would probably also be worth adding a check for `ok == true` and handling the error case more gracefully if the identity call fails. Without more info about why Slack is refusing to fill the request in some cases, it's probably best to leave a conditional in and try to fetch the user info if not available in the initial response.
