### PR TITLE
Set secure flag for remember_me cookie

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -31,6 +31,11 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.remember_me_httponly =
 
+  # Set secure flag for remember_me cookie
+  # Default: `false`
+  #
+  # config.remember_me_secure =
+
   # Set token randomness. (e.g. user activation tokens)
   # The length of the result string is about 4/3 of `token_randomness`.
   # Default: `15`

--- a/lib/sorcery/controller/submodules/remember_me.rb
+++ b/lib/sorcery/controller/submodules/remember_me.rb
@@ -10,9 +10,9 @@ module Sorcery
           base.send(:include, InstanceMethods)
           Config.module_eval do
             class << self
-              attr_accessor :remember_me_httponly
+              attr_accessor :remember_me_httponly, :remember_me_secure
               def merge_remember_me_defaults!
-                @defaults.merge!(:@remember_me_httponly => true)
+                @defaults.merge!(:@remember_me_httponly => true, :@remember_me_secure => false)
               end
             end
             merge_remember_me_defaults!
@@ -71,7 +71,8 @@ module Sorcery
               value: user.send(user.sorcery_config.remember_me_token_attribute_name),
               expires: user.send(user.sorcery_config.remember_me_token_expires_at_attribute_name),
               httponly: Config.remember_me_httponly,
-              domain: Config.cookie_domain
+              domain: Config.cookie_domain,
+              secure: Config.remember_me_secure
             }
           end
         end


### PR DESCRIPTION
Added the ability to set the secure flag for the remember_me cookie

Please ensure your pull request includes the following:

- [ ] Description of changes
- [ ] Update to CHANGELOG.md with short description and link to pull request
- [ ] Changes have related RSpec tests that ensure functionality does not break
