### PR TITLE
Fix/session timeout

### DIFF
--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -52,6 +52,7 @@ module Sorcery
           def validate_session
             session_to_use = Config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
             if (session_to_use && sorcery_session_expired?(session_to_use.to_time)) || sorcery_session_invalidated?
+              forget_me! if current_user.present? && Config.submodules.include?(:remember_me)
               reset_sorcery_session
               remove_instance_variable :@current_user if defined? @current_user
             else


### PR DESCRIPTION
Please ensure your pull request includes the following:

- [ ] Description of changes
- [ ] Update to CHANGELOG.md with short description and link to pull request
- [x] Changes have related RSpec tests that ensure functionality does not break

# Description
When :remember_me, :session_timeout module are on, the user is not logged out when the first session ends, because session_timeout invalidate the session and remember_me module creates another after that. With this problem we cant logged out a user with timeout when remember_me is on

# Solution
Forget remember me token in session_timeout

closes #303 