### PR TITLE
Fix the way the external provider class is instantiated for providers with plural names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ## 0.16.2
 
-* Fix provider instantiation for plural provider names (eg. okta) [#281](https://github.com/Sorcery/sorcery/pull/281)
 * Inline core migration index definition [#281](https://github.com/Sorcery/sorcery/pull/281)
 * Add missing remember_me attributes to config [#180](https://github.com/Sorcery/sorcery/pull/180)
 * Fix MongoID adapter breaking on save [#284](https://github.com/Sorcery/sorcery/pull/284)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 ## HEAD
 
+## 0.16.3
+
+* Fix provider instantiation for plural provider names (eg. okta) [#305](https://github.com/Sorcery/sorcery/pull/305)
+
 ## 0.16.2
 
+* Fix provider instantiation for plural provider names (eg. okta) [#281](https://github.com/Sorcery/sorcery/pull/281)
 * Inline core migration index definition [#281](https://github.com/Sorcery/sorcery/pull/281)
 * Add missing remember_me attributes to config [#180](https://github.com/Sorcery/sorcery/pull/180)
 * Fix MongoID adapter breaking on save [#284](https://github.com/Sorcery/sorcery/pull/284)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 ## HEAD
 
-## 0.16.3
-
 * Fix provider instantiation for plural provider names (eg. okta) [#305](https://github.com/Sorcery/sorcery/pull/305)
 
 ## 0.16.2

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -40,7 +40,7 @@ module Sorcery
                 providers.each do |name|
                   class_eval <<-RUBY, __FILE__, __LINE__ + 1
                     def self.#{name}
-                      @#{name} ||= Sorcery::Providers.const_get('#{name}'.to_s.classify).new
+                      @#{name} ||= Sorcery::Providers.const_get('#{name}'.to_s.capitalize).new
                     end
                   RUBY
                 end

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -40,7 +40,7 @@ module Sorcery
                 providers.each do |name|
                   class_eval <<-RUBY, __FILE__, __LINE__ + 1
                     def self.#{name}
-                      @#{name} ||= Sorcery::Providers.const_get('#{name}'.to_s.capitalize).new
+                      @#{name} ||= Sorcery::Providers.const_get('#{name}'.to_s.camelcase).new
                     end
                   RUBY
                 end

--- a/spec/providers/examples_spec.rb
+++ b/spec/providers/examples_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sorcery/providers/base'
+
+describe Sorcery::Providers::Examples do
+  before(:all) do
+    sorcery_reload!([:external])
+    sorcery_controller_property_set(:external_providers, [:examples])
+  end
+
+  context 'fetching a plural custom provider' do
+    it 'returns the provider' do
+      expect(Sorcery::Controller::Config.examples).to be_a(Sorcery::Providers::Examples)
+    end
+  end
+end

--- a/spec/support/providers/examples.rb
+++ b/spec/support/providers/examples.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'sorcery/providers/base'
+
+module Sorcery
+  module Providers
+    class Examples < Base
+      include Protocols::Oauth2
+    end
+  end
+end


### PR DESCRIPTION
When the external provider is specified as Okta, we get errors of the form `uninitialized constant Sorcery::Providers::Oktum`. The reason for this is that in the external providers file, the code was recently changed from using `capitalize` to `classify`. Unfortunately `'okta'.classify` resolves to 'Oktum' in ruby, causing this error.

Linked issue: https://github.com/Sorcery/sorcery/issues/306

- [x] Description of changes
- [x] Update to CHANGELOG.md with short description and link to pull request
- [x] Changes have related RSpec tests that ensure functionality does not break
