### PR TITLE
Fix broken builds (net/smtp)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please complete all sections.
+<!-- Please complete all sections. -->
 
 ### Configuration
 
@@ -9,12 +9,16 @@ Please complete all sections.
 
 ### Expected Behavior
 
-Tell us what should happen.
+<!-- Tell us what should happen. -->
 
 ### Actual Behavior
 
-Tell us what happens instead.
+<!-- Tell us what happens instead. -->
 
 ### Steps to Reproduce
 
-Please list all steps to reproduce the issue.
+<!-- Please list all steps to reproduce the issue. -->
+
+1.
+2.
+3.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,5 @@ Please ensure your pull request includes the following:
 - [ ] Description of changes
 - [ ] Update to CHANGELOG.md with short description and link to pull request
 - [ ] Changes have related RSpec tests that ensure functionality does not break
+
+<!-- For the changelog, please add your entry to the HEAD section. Do not create a new release header. -->

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,10 +25,16 @@ jobs:
         rails:
           - '52'
           - '60'
+          - '61'
+          - '70'
 
         exclude:
           - ruby: 2.4
             rails: '60'
+          - ruby: 2.4
+            rails: '61'
+          - ruby: 2.4
+            rails: '70'
           - ruby: 3.0
             rails: '52'
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,33 +21,33 @@ jobs:
           - 2.6
           - 2.7
           - 3.0.0
-          - 3.1
+          # - 3.1
 
         rails:
           - '52'
           - '60'
           - '61'
-          - '70'
+          # - '70'
 
         exclude:
           - ruby: 2.4
             rails: '60'
           - ruby: 2.4
             rails: '61'
-          - ruby: 2.4
-            rails: '70'
-          - ruby: 2.5
-            rails: '70'
-          - ruby: 2.6
-            rails: '70'
-          - ruby: 3.0.0
-            rails: '52'
-          - ruby: 3.1
-            rails: '52'
-          - ruby: 3.1
-            rails: '60'
-          - ruby: 3.1
-            rails: '61'
+          # - ruby: 2.4
+          #   rails: '70'
+          # - ruby: 2.5
+          #   rails: '70'
+          # - ruby: 2.6
+          #   rails: '70'
+          # - ruby: 3.0.0
+          #   rails: '52'
+          # - ruby: 3.1
+          #   rails: '52'
+          # - ruby: 3.1
+          #   rails: '60'
+          # - ruby: 3.1
+          #   rails: '61'
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - 3.0.0
+          - 3.1
 
         rails:
           - '52'
@@ -35,8 +36,18 @@ jobs:
             rails: '61'
           - ruby: 2.4
             rails: '70'
-          - ruby: 3.0
+          - ruby: 2.5
+            rails: '70'
+          - ruby: 2.6
+            rails: '70'
+          - ruby: 3.0.0
             rails: '52'
+          - ruby: 3.1
+            rails: '52'
+          - ruby: 3.1
+            rails: '60'
+          - ruby: 3.1
+            rails: '61'
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,8 +40,8 @@ jobs:
           #   rails: '70'
           # - ruby: 2.6
           #   rails: '70'
-          # - ruby: 3.0.0
-          #   rails: '52'
+          - ruby: 3.0.0
+            rails: '52'
           # - ruby: 3.1
           #   rails: '52'
           # - ruby: 3.1

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 6.1.0'
+gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.4'
+
+gemspec path: '..'

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.0.0'
+gem 'rails-controller-testing'
+gem 'sqlite3', '~> 1.4'
+
+gemspec path: '..'


### PR DESCRIPTION
Currently the builds are broken due to changes in how net/smtp is included in ruby itself. Updating the version matrices and gemfiles to address these changes.