### PR TITLE
adapt to Rails 7.0 defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## HEAD
 
+* Adapt to open request protection strategy of rails 7.0 [#318](https://github.com/Sorcery/sorcery/pull/318)
+
 ## 0.16.3
 
 * Fix provider instantiation for plural provider names (eg. okta) [#305](https://github.com/Sorcery/sorcery/pull/305)

--- a/lib/sorcery/controller/submodules/external.rb
+++ b/lib/sorcery/controller/submodules/external.rb
@@ -118,7 +118,7 @@ module Sorcery
           # sends user to authenticate at the provider's website.
           # after authentication the user is redirected to the callback defined in the provider config
           def login_at(provider_name, args = {})
-            redirect_to sorcery_login_url(provider_name, args)
+            redirect_to sorcery_login_url(provider_name, args), allow_other_host: true
           end
 
           # tries to login the user from provider's callback


### PR DESCRIPTION
Since 7.0, Rails protects against redirecting to external hosts
https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_to-label-Open+Redirect+protection
This change adapts to this by adding the option `allow_other_host` to the method call