### PR TITLE
Update version lock for oauth2 to v2 per v1 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## HEAD
 
 * Adapt to open request protection strategy of rails 7.0 [#318](https://github.com/Sorcery/sorcery/pull/318)
+* Update OAuth2 gem to v2 per v1 deprecation [#323](https://github.com/Sorcery/sorcery/pull/323)
 
 ## 0.16.3
 

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bcrypt', '~> 3.1'
   s.add_dependency 'oauth', '~> 0.5', '>= 0.5.5'
-  s.add_dependency 'oauth2', '~> 1.0', '>= 0.8.0'
+  s.add_dependency 'oauth2', '~> 2.0'
 
   s.add_development_dependency 'byebug', '~> 10.0.0'
   s.add_development_dependency 'rspec-rails', '~> 3.7.0'


### PR DESCRIPTION
Please ensure your pull request includes the following:

- [x] Description of changes
- [x] Update to CHANGELOG.md with short description and link to pull request
- [x] Changes have related RSpec tests that ensure functionality does not break

<!-- For the changelog, please add your entry to the HEAD section. Do not create a new release header. -->

Fixes #317 