### PR TITLE
Raise ArgumentError when calling change_password! with blank password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## HEAD
 
+* Raise ArgumentError when calling change_password! with blank password [#333](https://github.com/Sorcery/sorcery/pull/333)
+
 ## 0.16.4
 
 * Adapt to open request protection strategy of rails 7.0 [#318](https://github.com/Sorcery/sorcery/pull/318)

--- a/lib/sorcery/model/submodules/reset_password.rb
+++ b/lib/sorcery/model/submodules/reset_password.rb
@@ -131,6 +131,8 @@ module Sorcery
           end
 
           def change_password!(new_password)
+            raise ArgumentError, 'Blank password passed to change_password!' if new_password.blank?
+
             change_password(new_password, raise_on_failure: true)
           end
 

--- a/spec/shared_examples/user_reset_password_shared_examples.rb
+++ b/spec/shared_examples/user_reset_password_shared_examples.rb
@@ -328,6 +328,18 @@ shared_examples_for 'rails_3_reset_password_model' do
       expect(user.reset_password_token).to be_nil
     end
 
+    it 'when change_password! is called with empty argument, raise an exception' do
+      expect {
+        user.change_password!('')
+      }.to raise_error(ArgumentError, 'Blank password passed to change_password!')
+    end
+
+    it 'when change_password! is called with nil argument, raise an exception' do
+      expect {
+        user.change_password!(nil)
+      }.to raise_error(ArgumentError, 'Blank password passed to change_password!')
+    end
+
     it 'when change_password is called, deletes reset_password_token and calls #save' do
       new_password = 'blabulsdf'
 


### PR DESCRIPTION
Close #329

When calling `@user.change_password!("")` or `@user.change_password!(nil)`, a `ArgumentError` exception is now raised, because the password is missing, so it won't be modified.

Please ensure your pull request includes the following:

- [x] Description of changes
- [x] Update to CHANGELOG.md with short description and link to pull request
- [x] Changes have related RSpec tests that ensure functionality does not break

<!-- For the changelog, please add your entry to the HEAD section. Do not create a new release header. -->
