### PR TITLE
Fix timestamped_migrations method call since deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## HEAD
-
+* Fix deprecated call to timestamped_migrations in the install generateor [#338](https://github.com/Sorcery/sorcery/pull/338)
 * Raise ArgumentError when calling change_password! with blank password [#333](https://github.com/Sorcery/sorcery/pull/333)
 
 ## 0.16.4

--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -75,7 +75,7 @@ module Sorcery
 
       # Define the next_migration_number method (necessary for the migration_template method to work)
       def self.next_migration_number(dirname)
-        if ActiveRecord::Base.timestamped_migrations
+        if ActiveRecord.timestamped_migrations
           sleep 1 # make sure each time we get a different timestamp
           Time.new.utc.strftime('%Y%m%d%H%M%S')
         else


### PR DESCRIPTION
Per Rails 7.x, 
```
DEPRECATION WARNING: ActiveRecord::Base.timestamped_migrations is deprecated and will be removed in Rails 7.1.
Use `ActiveRecord.timestamped_migrations` instead.   
```

This method was removed in Rails 7.1, breaking the sorcery installer. Following the guidance from the deprecation warning, the fix listed above works. 
