### PR TITLE
Remove duplicate method in InstallGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## HEAD
 
+* Fix error when running the install generator [#339](https://github.com/Sorcery/sorcery/pull/339)
 * Raise ArgumentError when calling change_password! with blank password [#333](https://github.com/Sorcery/sorcery/pull/333)
 
 ## 0.16.4

--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -48,7 +48,6 @@ module Sorcery
         return if only_submodules?
 
         generate "model #{model_class_name} --skip-migration"
-        inject_sorcery_to_model
       end
 
       def inject_sorcery_to_model


### PR DESCRIPTION
There's no need to call `inject_sorcery_to_model` in the previous method, since the generators execute all public methods in order.

That's why we had an error in the logs: the method was called twice.

Close #265