### PR TITLE
session_timeout: make sure remember_me's before_logout hook gets called

### DIFF
--- a/lib/sorcery/controller/submodules/session_timeout.rb
+++ b/lib/sorcery/controller/submodules/session_timeout.rb
@@ -52,8 +52,7 @@ module Sorcery
           def validate_session
             session_to_use = Config.session_timeout_from_last_action ? session[:last_action_time] : session[:login_time]
             if (session_to_use && sorcery_session_expired?(session_to_use.to_time)) || sorcery_session_invalidated?
-              reset_sorcery_session
-              remove_instance_variable :@current_user if defined? @current_user
+              logout
             else
               session[:last_action_time] = Time.now.in_time_zone
             end


### PR DESCRIPTION
## The Problem
+ if an app uses both the `session_timeout` as well as the `remember_me` submodule the following can happen:
   + even if a user's `invalidate_sessions_before` timestamp is set to `now`, their remember_me sessions will not be invalidated
   + reason: the remember_me cookie doesn't get deleted during the `session_timeout` submodule's `validate_session`

## In the code:
+ only `logout` calls before & after logout hooks:
  https://github.com/Sorcery/sorcery/blob/d9dc0bd80a3d5689398baea4489b14ed78e6c42d/lib/sorcery/controller.rb#L75-L78

+ `remember_me` uses a `before_logout` hook to clear its cookie:
  https://github.com/Sorcery/sorcery/blob/d9dc0bd80a3d5689398baea4489b14ed78e6c42d/lib/sorcery/controller/submodules/remember_me.rb#L22