### PR TITLE
Bump up required ruby version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## HEAD
 
+* Bump up required ruby version to 3.0.0 [#369](https://github.com/Sorcery/sorcery/pull/369)
+
 ## 0.17.0
 
 * Fix Rails 7.1 compatibility by using `ActiveRecord.timestamped_migrations` [#352](https://github.com/Sorcery/sorcery/pull/352)

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.required_ruby_version = '>= 2.4.9'
+  s.required_ruby_version = '>= 3.0.0'
 
   s.add_dependency 'bcrypt', '~> 3.1'
   s.add_dependency 'oauth', '>= 0.6'


### PR DESCRIPTION
This commit is related to https://github.com/Sorcery/sorcery/issues/340. In https://github.com/Sorcery/sorcery/pull/357, we limited CI support to Ruby 3.0 and above, but in the gemspec, we still had dependencies set for older Ruby versions.