### PR TITLE
Add metadata to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## HEAD
 
+* Add bug tracker & changelog URLs to gemspec metadata [#372](https://github.com/Sorcery/sorcery/pull/372)
 * Remove form_authenticity_token method [#371](https://github.com/Sorcery/sorcery/pull/371)
 * Remove legacy Rails version conditionals [#370](https://github.com/Sorcery/sorcery/pull/370)
 * Bump up required ruby version to 3.0.0 [#369](https://github.com/Sorcery/sorcery/pull/369)

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.description = 'Provides common authentication needs such as signing in/out, activating by email and resetting password.'
   s.summary = 'Magical authentication for Rails applications'
   s.homepage = 'https://github.com/Sorcery/sorcery'
+  s.metadata = {"bug_tracker_uri" => "https://github.com/Sorcery/sorcery/issues", "changelog_uri" => "https://github.com/Sorcery/sorcery/blob/master/CHANGELOG.md"} if s.respond_to? :metadata=
   s.post_install_message = "As of version 1.0 oauth/oauth2 won't be automatically bundled so you may need to add those dependencies to your Gemfile.\n"
   s.post_install_message += 'You may need oauth2 if you use external providers such as any of these: https://github.com/Sorcery/sorcery/tree/master/lib/sorcery/providers'
   # rubocop:enable Layout/LineLength

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.description = 'Provides common authentication needs such as signing in/out, activating by email and resetting password.'
   s.summary = 'Magical authentication for Rails applications'
   s.homepage = 'https://github.com/Sorcery/sorcery'
-  s.metadata = {"bug_tracker_uri" => "https://github.com/Sorcery/sorcery/issues", "changelog_uri" => "https://github.com/Sorcery/sorcery/blob/master/CHANGELOG.md"} if s.respond_to? :metadata=
+  s.metadata = {"bug_tracker_uri" => "https://github.com/Sorcery/sorcery/issues", "changelog_uri" => "https://github.com/Sorcery/sorcery/blob/master/CHANGELOG.md"}
   s.post_install_message = "As of version 1.0 oauth/oauth2 won't be automatically bundled so you may need to add those dependencies to your Gemfile.\n"
   s.post_install_message += 'You may need oauth2 if you use external providers such as any of these: https://github.com/Sorcery/sorcery/tree/master/lib/sorcery/providers'
   # rubocop:enable Layout/LineLength


### PR DESCRIPTION
This allows rubygems.org to display useful shortcuts:

![image](https://github.com/Sorcery/sorcery/assets/38524/4630259d-a037-47cb-ad31-10bffe7d8055)
