### PR TITLE
Remove unused SimpleCov

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## HEAD
 
+* Remove unused SimpleCov [#374](https://github.com/Sorcery/sorcery/pull/374) 
 * Add bug tracker & changelog URLs to gemspec metadata [#372](https://github.com/Sorcery/sorcery/pull/372)
 * Remove form_authenticity_token method [#371](https://github.com/Sorcery/sorcery/pull/371)
 * Remove legacy Rails version conditionals [#370](https://github.com/Sorcery/sorcery/pull/370)

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug', '~> 10.0.0'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'simplecov', '>= 0.3.8'
   s.add_development_dependency 'test-unit', '~> 3.2.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'webmock', '~> 3.3.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,6 @@ ENV['RAILS_ENV'] ||= 'test'
 
 SORCERY_ORM = :active_record
 
-# require 'simplecov'
-# SimpleCov.root File.join(File.dirname(__FILE__), '..', 'lib')
-# SimpleCov.start
 require 'rails/all'
 require 'rspec/rails'
 require 'timecop'


### PR DESCRIPTION
I couldn’t find any code using SimpleCov, other than the commented-out sections removed in this commit, so it seems SimpleCov is not currently in use.