### PR TITLE
Drop support for versions below Ruby 3.2 and Rails 7.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,36 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.0'
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
 
         rails:
-          - '61'
-          - '70'
           - '71'
           - '72'
           - '80'
-
-        exclude:
-          - ruby: '3.4'
-            rails: '70'
-          - ruby: '3.4'
-            rails: '61'
-          - ruby: '3.3'
-            rails: '70'
-          - ruby: '3.3'
-            rails: '61'
-          - ruby: '3.2'
-            rails: '61'
-          - ruby: '3.0'
-            rails: '72'
-          - ruby: '3.0'
-            rails: '80'
-          - ruby: '3.1'
-            rails: '80'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## HEAD
+
+* Drop support for versions below Ruby 3.2 and Rails 7.1 [#383](https://github.com/Sorcery/sorcery/pull/383)
 * Remove the dependency on OpenStruct in the test code [#382](https://github.com/Sorcery/sorcery/pull/382)
 * Add Ruby 3.4 to CI matrix [#381](https://github.com/Sorcery/sorcery/pull/381)
 * Fix CI failures [#379](https://github.com/Sorcery/sorcery/pull/379)

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 6.1.0'
-gem 'concurrent-ruby', '1.3.4'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4'
-gem 'rspec-rails', '>= 5.0'
-gemspec path: '..'

--- a/gemfiles/rails_70.gemfile
+++ b/gemfiles/rails_70.gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 7.0.0'
-gem 'concurrent-ruby', '1.3.4'
-gem 'rails-controller-testing'
-gem 'sqlite3', '~> 1.4'
-gem 'rspec-rails', '>= 6.0'
-gemspec path: '..'

--- a/lib/sorcery/adapters/mongoid_adapter.rb
+++ b/lib/sorcery/adapters/mongoid_adapter.rb
@@ -2,7 +2,7 @@ module Sorcery
   module Adapters
     class MongoidAdapter < BaseAdapter
       def increment(attr)
-        mongoid_4? ? @model.inc(attr => 1) : @model.inc(attr, 1)
+        @model.inc(attr => 1)
       end
 
       def update_attributes(attrs)
@@ -22,9 +22,6 @@ module Sorcery
         @model.send(mthd, options)
       end
 
-      def mongoid_4?
-        Gem::Version.new(::Mongoid::VERSION) >= Gem::Version.new('4.0.0.alpha')
-      end
 
       class << self
         def define_field(name, type, options = {})

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.required_ruby_version = '>= 3.0.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   s.add_dependency 'bcrypt', '~> 3.1'
   s.add_dependency 'oauth', '>= 0.6'

--- a/spec/support/migration_helper.rb
+++ b/spec/support/migration_helper.rb
@@ -1,24 +1,11 @@
 class MigrationHelper
   class << self
     def migrate(path)
-      if Rails.version >= '7.0'
-        ActiveRecord::MigrationContext.new(path).migrate
-      elsif Rails.version < '7.0'
-        ActiveRecord::MigrationContext.new(path, schema_migration).migrate
-      end
+      ActiveRecord::MigrationContext.new(path).migrate
     end
 
     def rollback(path)
-      if Rails.version >= '7.0'
-        ActiveRecord::MigrationContext.new(path).rollback
-      elsif Rails.version < '7.0'
-        ActiveRecord::MigrationContext.new(path, schema_migration).rollback
-      end
-    end
-
-    private
-    def schema_migration
-      ActiveRecord::Base.connection.schema_migration
+      ActiveRecord::MigrationContext.new(path).rollback
     end
   end
 end


### PR DESCRIPTION
Sorcery only supports the currently officially supported versions of Ruby and Rails.

Also remove conditionals for Rails versions older than 7.0, and mongoid versions older than 4.0

Mongoid 3.x is no longer relevant since its latest release (v3.1.7) depends on `activemodel ~> 3.2`, which is incompatible with current versions of Sorcery. See: https://github.com/mongodb/mongoid/blob/v3.1.7/mongoid.gemspec#L22


