### PR TITLE
Remove check for rails-controller-testing gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## HEAD
 
+* Remove check for rails-controller-testing gem [#385](https://github.com/Sorcery/sorcery/pull/385)
 * Remove Testing Matrix from README [#384](https://github.com/Sorcery/sorcery/pull/384)
 * Drop support for versions below Ruby 3.2 and Rails 7.1 [#383](https://github.com/Sorcery/sorcery/pull/383)
 * Remove the dependency on OpenStruct in the test code [#382](https://github.com/Sorcery/sorcery/pull/382)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,13 +35,7 @@ RSpec.configure do |config|
   config.include ::Sorcery::TestHelpers::Internal
   config.include ::Sorcery::TestHelpers::Internal::Rails
 
-  if begin
-       Module.const_defined?('::Rails::Controller::Testing')
-     rescue StandardError
-       false
-     end
-    config.include ::Rails::Controller::Testing::TestProcess, type: :controller
-    config.include ::Rails::Controller::Testing::TemplateAssertions, type: :controller
-    config.include ::Rails::Controller::Testing::Integration, type: :controller
-  end
+  config.include ::Rails::Controller::Testing::TestProcess, type: :controller
+  config.include ::Rails::Controller::Testing::TemplateAssertions, type: :controller
+  config.include ::Rails::Controller::Testing::Integration, type: :controller
 end


### PR DESCRIPTION
The `rails-controller-testing` gem provided helper methods for controller tests up to Rails 4.2. This condition was used to support testing with both Rails 4.2 and Rails 5+. Since we no longer test with Rails versions below 5, the condition is no longer necessary.

ref: https://github.com/Sorcery/sorcery/pull/21

