### PR TITLE
Fix a pending test

### DIFF
--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -70,18 +70,20 @@ describe SorceryController, type: :controller do
       stub_all_oauth_requests!
     end
 
+    after do
+      sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:twitter, :original_callback_url, nil)
+    end
+
     context 'when callback_url begins with /' do
       before do
         sorcery_controller_external_property_set(:twitter, :callback_url, '/oauth/twitter/callback')
       end
+
       it 'login_at redirects correctly' do
         get :login_at_test
         expect(response).to be_a_redirect
         expect(response).to redirect_to('http://myapi.com/oauth/authorize?oauth_callback=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&oauth_token=')
-      end
-      after do
-        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
-        sorcery_controller_external_property_set(:twitter, :original_callback_url, nil)
       end
     end
 
@@ -89,14 +91,11 @@ describe SorceryController, type: :controller do
       before do
         sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com/oauth/twitter/callback')
       end
+
       it 'login_at redirects correctly' do
         get :login_at_test
         expect(response).to be_a_redirect
         expect(response).to redirect_to('http://myapi.com/oauth/authorize?oauth_callback=http%3A%2F%2Fblabla.com%2Foauth%2Ftwitter%2Fcallback&oauth_token=')
-      end
-      after do
-        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
-        sorcery_controller_external_property_set(:twitter, :original_callback_url, nil)
       end
     end
 


### PR DESCRIPTION
Simply removing pending and adjusting the value allowed the test to pass when run individually(e.g., `rspec ./spec/controllers/controller_oauth_spec.rb:93`), but it failed when runnning the whole file (e.g., rspec ./spec/controllers/controller_oauth_spec.rb)

The cause was that the test above was updating `original_callback_url`, and it wasn't beging reset for test next test ( [related code](https://github.com/Sorcery/sorcery/blob/24463e026609072ee51be30a8539a22f97844078/lib/sorcery/controller/submodules/external.rb#L106) ).

Resetting `original_callback_url` in each test made the test pass.
