### PR TITLE
Stop the policy of manually updating the Changelog per PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,4 @@
 Please ensure your pull request includes the following:
 
 - [ ] Description of changes
-- [ ] Update to CHANGELOG.md with short description and link to pull request
 - [ ] Changes have related RSpec tests that ensure functionality does not break
-
-<!-- For the changelog, please add your entry to the HEAD section. Do not create a new release header. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,8 @@
 # Changelog
-## HEAD
-* Limit the files included in the gem to only the necessary ones [#386](https://github.com/Sorcery/sorcery/pull/386)
-* Remove check for rails-controller-testing gem [#385](https://github.com/Sorcery/sorcery/pull/385)
-* Remove Testing Matrix from README [#384](https://github.com/Sorcery/sorcery/pull/384)
-* Drop support for versions below Ruby 3.2 and Rails 7.1 [#383](https://github.com/Sorcery/sorcery/pull/383)
-* Remove the dependency on OpenStruct in the test code [#382](https://github.com/Sorcery/sorcery/pull/382)
-* Add Ruby 3.4 to CI matrix [#381](https://github.com/Sorcery/sorcery/pull/381)
-* Fix CI failures [#379](https://github.com/Sorcery/sorcery/pull/379)
-* Fixed minor issues with test to get all green so that we can continue development [#377](https://github.com/Sorcery/sorcery/pull/377)
-* Remove unused SimpleCov [#374](https://github.com/Sorcery/sorcery/pull/374)
-* Add bug tracker & changelog URLs to gemspec metadata [#372](https://github.com/Sorcery/sorcery/pull/372)
-* Remove form_authenticity_token method [#371](https://github.com/Sorcery/sorcery/pull/371)
-* Remove legacy Rails version conditionals [#370](https://github.com/Sorcery/sorcery/pull/370)
-* Bump up required ruby version to 3.0.0 [#369](https://github.com/Sorcery/sorcery/pull/369)
-* Move `token_randomness` config to Model::Config in initializer template [#375](https://github.com/Sorcery/sorcery/pull/375)
+
+**Note: As of version 0.17.0, we no longer maintain this CHANGELOG.md file manually. For the latest changes and release notes, please refer to [GitHub Releases](https://github.com/Sorcery/sorcery/releases).**
+
+This file contains historical changelog entries for reference. New releases and their changes are documented in GitHub Releases.
 
 ## 0.17.0
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -43,14 +43,10 @@ this checklist and prepare a release commit:
 NOTE: `X.Y.Z` and `vX.Y.Z` are given as examples, and should be replaced with
       whatever version you are releasing. See: [Version Naming](#version-naming)
 
-1. Update CHANGELOG.md
-   1. Check for any changes that have been included since the last release that
-      are not reflected in the changelog. Add any missing entries to the `HEAD`
-      section.
-   1. Check the changes in `HEAD` to determine what version increment is
-      appropriate. See [Version Naming](#version-naming) if unsure.
-   1. Replace `## HEAD` with `## vX.Y.Z` and create a new `## HEAD` section
-      above the latest version.
+1. Decide the next version number
+   1. Review all changes that have been included since the last release.
+   1. Check the changes to determine what version increment is appropriate.
+      See [Version Naming](#version-naming) if unsure.
 1. Update Gem Version
    1. Update `./lib/sorcery/version.rb` to 'X.Y.Z'
 1. Stage your changes and create a commit
@@ -60,5 +56,8 @@ NOTE: `X.Y.Z` and `vX.Y.Z` are given as examples, and should be replaced with
    1. `cd <dir>`
    1. `gem build`
    1. `gem push <filename>`
-1. TODO: Version tagging
-   1. Release new version via github interface
+1. Create GitHub Release
+   1. Create a new release via GitHub interface at https://github.com/Sorcery/sorcery/releases/new
+   1. Use tag `vX.Y.Z` and title `vX.Y.Z`
+   1. Include the prepared release notes in the description
+   1. This will automatically create the git tag and publish the release

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.description = 'Provides common authentication needs such as signing in/out, activating by email and resetting password.'
   s.summary = 'Magical authentication for Rails applications'
   s.homepage = 'https://github.com/Sorcery/sorcery'
-  s.metadata = {"bug_tracker_uri" => "https://github.com/Sorcery/sorcery/issues", "changelog_uri" => "https://github.com/Sorcery/sorcery/blob/master/CHANGELOG.md"}
+  s.metadata = {"bug_tracker_uri" => "https://github.com/Sorcery/sorcery/issues", "changelog_uri" => "https://github.com/Sorcery/sorcery/releases"}
   s.post_install_message = "As of version 1.0 oauth/oauth2 won't be automatically bundled so you may need to add those dependencies to your Gemfile.\n"
   s.post_install_message += 'You may need oauth2 if you use external providers such as any of these: https://github.com/Sorcery/sorcery/tree/master/lib/sorcery/providers'
   # rubocop:enable Layout/LineLength


### PR DESCRIPTION
Currently, our policy requires manually adding changes to CHANGELOG.md for every PR on GitHub. This often causes conflicts when multiple PRs are open, and merging one of them leads to conflicts in all the others. Additionally, resolving these conflicts after approval requires re-approval, increasing the maintenance burden.

GitHub’s Releases page now supports automatic generation of changelogs. Going forward, we’d like to rely on this feature and stop manually writing the Changelog to reduce maintenance overhead.
