### PR TITLE
Change test domains to use "example.com" wherever possible

### DIFF
--- a/lib/sorcery/test_helpers/internal.rb
+++ b/lib/sorcery/test_helpers/internal.rb
@@ -24,7 +24,7 @@ module Sorcery
       end
 
       def build_new_user(attributes_hash = nil)
-        user_attributes_hash = attributes_hash || { username: 'gizmo', email: 'bla@bla.com', password: 'secret' }
+        user_attributes_hash = attributes_hash || { username: 'gizmo', email: 'bla@example.com', password: 'secret' }
         @user = User.new(user_attributes_hash)
       end
 

--- a/spec/controllers/controller_brute_force_protection_spec.rb
+++ b/spec/controllers/controller_brute_force_protection_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe SorceryController, type: :controller do
-  let!(:user) { User.create!(username: 'test_user', email: 'bla@bla.com', password: 'password') }
+  let!(:user) { User.create!(username: 'test_user', email: 'bla@example.com', password: 'password') }
 
   def request_test_login
-    get :test_login, params: { email: 'bla@bla.com', password: 'blabla' }
+    get :test_login, params: { email: 'bla@example.com', password: 'blabla' }
   end
 
   # ----------------- BRUTE FORCE PROTECTION -----------------------
@@ -20,7 +20,7 @@ describe SorceryController, type: :controller do
 
     it 'counts login retries' do
       allow(User).to receive(:authenticate) { |&block| block.call(nil, :other) }
-      allow(User.sorcery_adapter).to receive(:find_by_credentials).with(['bla@bla.com', 'blabla']).and_return(user)
+      allow(User.sorcery_adapter).to receive(:find_by_credentials).with(['bla@example.com', 'blabla']).and_return(user)
 
       expect(user).to receive(:register_failed_login!).exactly(3).times
 
@@ -33,7 +33,7 @@ describe SorceryController, type: :controller do
 
       allow(User).to receive(:authenticate) { |&block| block.call(user, nil) }
 
-      get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+      get :test_login, params: { email: 'bla@example.com', password: 'secret' }
 
       user.reload
       expect(user.failed_logins_count).to eq(0)

--- a/spec/controllers/controller_http_basic_auth_spec.rb
+++ b/spec/controllers/controller_http_basic_auth_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SorceryController, type: :controller do
-  let!(:user) { User.create!(username: 'test_user', email: 'bla@bla.com', password: 'password') }
+  let!(:user) { User.create!(username: 'test_user', email: 'bla@example.com', password: 'password') }
 
   describe 'with http basic auth features' do
     before(:all) do
@@ -22,7 +22,7 @@ describe SorceryController, type: :controller do
 
     it 'authenticates from http basic if credentials are sent' do
       @request.env['HTTP_AUTHORIZATION'] = "Basic #{Base64.encode64("#{user.email}:secret")}"
-      expect(User).to receive('authenticate').with('bla@bla.com', 'secret').and_return(user)
+      expect(User).to receive('authenticate').with('bla@example.com', 'secret').and_return(user)
       get :test_http_basic_auth, params: {}, session: { http_authentication_used: true }
 
       expect(response).to be_successful
@@ -30,7 +30,7 @@ describe SorceryController, type: :controller do
 
     it 'fails authentication if credentials are wrong' do
       @request.env['HTTP_AUTHORIZATION'] = "Basic #{Base64.encode64("#{user.email}:wrong!")}"
-      expect(User).to receive('authenticate').with('bla@bla.com', 'wrong!').and_return(nil)
+      expect(User).to receive('authenticate').with('bla@example.com', 'wrong!').and_return(nil)
       get :test_http_basic_auth, params: {}, session: { http_authentication_used: true }
 
       expect(response).to redirect_to root_url
@@ -51,7 +51,7 @@ describe SorceryController, type: :controller do
 
     it "signs in the user's session on successful login" do
       @request.env['HTTP_AUTHORIZATION'] = "Basic #{Base64.encode64("#{user.email}:secret")}"
-      expect(User).to receive('authenticate').with('bla@bla.com', 'secret').and_return(user)
+      expect(User).to receive('authenticate').with('bla@example.com', 'secret').and_return(user)
 
       get :test_http_basic_auth, params: {}, session: { http_authentication_used: true }
 

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -101,7 +101,7 @@ describe SorceryController, active_record: true, type: :controller do
       end
 
       after do
-        sorcery_controller_external_property_set(:facebook, :callback_url, 'http://blabla.com')
+        sorcery_controller_external_property_set(:facebook, :callback_url, 'http://example.com')
       end
     end
 
@@ -119,7 +119,7 @@ describe SorceryController, active_record: true, type: :controller do
       end
 
       after do
-        sorcery_controller_external_property_set(:facebook, :callback_url, 'http://blabla.com')
+        sorcery_controller_external_property_set(:facebook, :callback_url, 'http://example.com')
       end
     end
 
@@ -212,50 +212,50 @@ describe SorceryController, active_record: true, type: :controller do
       # TODO: refactor
       sorcery_controller_external_property_set(:facebook, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:facebook, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:facebook, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:facebook, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:github, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:github, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:github, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:github, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:google, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:google, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:google, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:google, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:liveid, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:liveid, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:liveid, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:liveid, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:vk, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:vk, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:vk, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:vk, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:salesforce, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:salesforce, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:salesforce, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:salesforce, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:paypal, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:paypal, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:paypal, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:paypal, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:slack, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:slack, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:slack, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:slack, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:wechat, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:wechat, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:wechat, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:wechat, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:microsoft, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:microsoft, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:microsoft, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:microsoft, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:instagram, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:instagram, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:instagram, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:instagram, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:auth0, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:auth0, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:auth0, :callback_url, 'http://blabla.com')
-      sorcery_controller_external_property_set(:auth0, :site, 'https://sorcery-test.auth0.com')
+      sorcery_controller_external_property_set(:auth0, :callback_url, 'http://example.com')
+      sorcery_controller_external_property_set(:auth0, :site, 'https://auth0.example.com')
       sorcery_controller_external_property_set(:line, :key, "eYVNBjBDi33aa9GkA3w")
       sorcery_controller_external_property_set(:line, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
-      sorcery_controller_external_property_set(:line, :callback_url, "http://blabla.com")
+      sorcery_controller_external_property_set(:line, :callback_url, "http://example.com")
       sorcery_controller_external_property_set(:discord, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:discord, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:discord, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:discord, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:battlenet, :key, '4c43d4862c774ca5bbde89873bf0d338')
       sorcery_controller_external_property_set(:battlenet, :secret, 'TxY7IwKOykACd8kUxPyVGTqBs44UBDdX')
-      sorcery_controller_external_property_set(:battlenet, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:battlenet, :callback_url, 'http://example.com')
     end
 
     after(:each) do
@@ -389,7 +389,7 @@ describe SorceryController, active_record: true, type: :controller do
         'name' => 'Noam Ben Ari',
         'first_name' => 'Noam',
         'last_name' => 'Ben Ari',
-        'link' => 'http://www.facebook.com/nbenari1',
+        'link' => 'http://profile.example.com/testuser1',
         'hometown' => {
           'id' => '110619208966868',
           'name' => 'Haifa, Israel'
@@ -400,7 +400,7 @@ describe SorceryController, active_record: true, type: :controller do
         },
         'bio' => "I'm a new daddy, and enjoying it!",
         'gender' => 'male',
-        'email' => 'nbenari@gmail.com',
+        'email' => 'nbenari@example.com',
         'timezone' => 2,
         'locale' => 'en_US',
         'languages' => [
@@ -439,7 +439,7 @@ describe SorceryController, active_record: true, type: :controller do
           'username' => 'pnmahoney',
           'bio' => 'turn WHAT down?',
           'website' => '',
-          'profile_picture' => 'http://photos-d.ak.instagram.com/hphotos-ak-xpa1/10454121_417985815007395_867850883_a.jpg',
+          'profile_picture' => 'http://images.example.com/test-profile.jpg',
           'full_name' => 'Patrick Mahoney',
           'counts' => {
             'media' => 2,
@@ -453,7 +453,7 @@ describe SorceryController, active_record: true, type: :controller do
     allow(access_token).to receive(:get) { response }
     allow(access_token).to receive(:token) { '187041a618229fdaf16613e96e1caabc1e86e46bbfad228de41520e63fe45873684c365a14417289599f3' }
     # access_token params for VK auth
-    allow(access_token).to receive(:params) { { 'user_id' => '100500', 'email' => 'nbenari@gmail.com' } }
+    allow(access_token).to receive(:params) { { 'user_id' => '100500', 'email' => 'nbenari@example.com' } }
     allow_any_instance_of(OAuth2::Strategy::AuthCode).to receive(:get_token) { access_token }
   end
 
@@ -480,67 +480,67 @@ describe SorceryController, active_record: true, type: :controller do
     )
     sorcery_controller_external_property_set(:facebook, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:facebook, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:facebook, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:facebook, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:github, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:github, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:github, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:github, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:google, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:google, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:google, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:google, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:liveid, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:liveid, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:liveid, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:liveid, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:vk, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:vk, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:vk, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:vk, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:salesforce, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:salesforce, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:salesforce, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:salesforce, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:paypal, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:paypal, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:paypal, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:paypal, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:slack, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:slack, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:slack, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:slack, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:wechat, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:wechat, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:wechat, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:wechat, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:microsoft, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:microsoft, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:microsoft, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:microsoft, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:instagram, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:instagram, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:instagram, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:instagram, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:auth0, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:auth0, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:auth0, :callback_url, 'http://blabla.com')
-    sorcery_controller_external_property_set(:auth0, :site, 'https://sorcery-test.auth0.com')
+    sorcery_controller_external_property_set(:auth0, :callback_url, 'http://example.com')
+    sorcery_controller_external_property_set(:auth0, :site, 'https://auth0.example.com')
     sorcery_controller_external_property_set(:line, :key, "eYVNBjBDi33aa9GkA3w")
     sorcery_controller_external_property_set(:line, :secret, "XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8")
-    sorcery_controller_external_property_set(:line, :callback_url, "http://blabla.com")
+    sorcery_controller_external_property_set(:line, :callback_url, "http://example.com")
     sorcery_controller_external_property_set(:discord, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:discord, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:discord, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:discord, :callback_url, 'http://example.com')
     sorcery_controller_external_property_set(:battlenet, :key, '4c43d4862c774ca5bbde89873bf0d338')
     sorcery_controller_external_property_set(:battlenet, :secret, 'TxY7IwKOykACd8kUxPyVGTqBs44UBDdX')
-    sorcery_controller_external_property_set(:battlenet, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:battlenet, :callback_url, 'http://example.com')
   end
 
   def provider_url(provider)
     {
-      github: "https://github.com/login/oauth/authorize?client_id=#{::Sorcery::Controller::Config.github.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope&state",
-      paypal: "https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize?client_id=#{::Sorcery::Controller::Config.paypal.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid%20email&state",
-      google: "https://accounts.google.com/o/oauth2/auth?client_id=#{::Sorcery::Controller::Config.google.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state",
-      liveid: "https://oauth.live.com/authorize?client_id=#{::Sorcery::Controller::Config.liveid.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=wl.basic%20wl.emails%20wl.offline_access&state",
-      vk: "https://oauth.vk.com/authorize?client_id=#{::Sorcery::Controller::Config.vk.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.vk.scope}&state",
-      salesforce: "https://login.salesforce.com/services/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.salesforce.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope#{'=' + ::Sorcery::Controller::Config.salesforce.scope unless ::Sorcery::Controller::Config.salesforce.scope.nil?}&state",
-      slack: "https://slack.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.slack.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=identity.basic%2C%20identity.email&state",
-      wechat: "https://open.weixin.qq.com/connect/qrconnect?appid=#{::Sorcery::Controller::Config.wechat.key}&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=snsapi_login&state=#wechat_redirect",
-      microsoft: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=#{::Sorcery::Controller::Config.microsoft.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid%20email%20https%3A%2F%2Fgraph.microsoft.com%2FUser.Read&state",
-      instagram: "https://api.instagram.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.instagram.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=#{::Sorcery::Controller::Config.instagram.scope}&state",
-      auth0: "https://sorcery-test.auth0.com/authorize?client_id=#{::Sorcery::Controller::Config.auth0.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid%20profile%20email&state",
-      discord: "https://discordapp.com/api/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.discord.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=identify&state",
-      battlenet: "https://eu.battle.net/oauth/authorize?client_id=#{::Sorcery::Controller::Config.battlenet.key}&display&redirect_uri=http%3A%2F%2Fblabla.com&response_type=code&scope=openid&state"
+      github: "https://github.com/login/oauth/authorize?client_id=#{::Sorcery::Controller::Config.github.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope&state",
+      paypal: "https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize?client_id=#{::Sorcery::Controller::Config.paypal.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=openid%20email&state",
+      google: "https://accounts.google.com/o/oauth2/auth?client_id=#{::Sorcery::Controller::Config.google.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile&state",
+      liveid: "https://oauth.live.com/authorize?client_id=#{::Sorcery::Controller::Config.liveid.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=wl.basic%20wl.emails%20wl.offline_access&state",
+      vk: "https://oauth.vk.com/authorize?client_id=#{::Sorcery::Controller::Config.vk.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=#{::Sorcery::Controller::Config.vk.scope}&state",
+      salesforce: "https://login.salesforce.com/services/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.salesforce.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope#{'=' + ::Sorcery::Controller::Config.salesforce.scope unless ::Sorcery::Controller::Config.salesforce.scope.nil?}&state",
+      slack: "https://slack.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.slack.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=identity.basic%2C%20identity.email&state",
+      wechat: "https://open.weixin.qq.com/connect/qrconnect?appid=#{::Sorcery::Controller::Config.wechat.key}&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=snsapi_login&state=#wechat_redirect",
+      microsoft: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=#{::Sorcery::Controller::Config.microsoft.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=openid%20email%20https%3A%2F%2Fgraph.microsoft.com%2FUser.Read&state",
+      instagram: "https://api.instagram.com/oauth/authorize?client_id=#{::Sorcery::Controller::Config.instagram.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=#{::Sorcery::Controller::Config.instagram.scope}&state",
+      auth0: "https://auth0.example.com/authorize?client_id=#{::Sorcery::Controller::Config.auth0.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=openid%20profile%20email&state",
+      discord: "https://discordapp.com/api/oauth2/authorize?client_id=#{::Sorcery::Controller::Config.discord.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=identify&state",
+      battlenet: "https://eu.battle.net/oauth/authorize?client_id=#{::Sorcery::Controller::Config.battlenet.key}&display&redirect_uri=http%3A%2F%2Fexample.com&response_type=code&scope=openid&state"
     }[provider]
   end
 end

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 # require 'shared_examples/controller_oauth_shared_examples'
 
 def stub_all_oauth_requests!
-  consumer = OAuth::Consumer.new('key', 'secret', site: 'http://myapi.com')
+  consumer = OAuth::Consumer.new('key', 'secret', site: 'http://api.example.com')
   req_token = OAuth::RequestToken.new(consumer)
   acc_token = OAuth::AccessToken.new(consumer)
 
@@ -11,7 +11,7 @@ def stub_all_oauth_requests!
   def response.body
     {
       'following' => false, 'listed_count' => 0, 'profile_link_color' => '0084B4',
-      'profile_image_url' => 'http://a1.twimg.com/profile_images/536178575/noamb_normal.jpg',
+      'profile_image_url' => 'http://media.example.com/profile_images/536178575/noamb_normal.jpg',
       'description' => 'Programmer/Heavy Metal Fan/New Father',
       'status' => {
         'text' => 'coming soon to sorcery gem: twitter and facebook authentication support.',
@@ -27,7 +27,7 @@ def stub_all_oauth_requests!
       'screen_name' => 'nbenari', 'profile_use_background_image' => true, 'location' => 'Israel',
       'statuses_count' => 25, 'profile_background_color' => '022330', 'lang' => 'en',
       'verified' => false, 'notifications' => false,
-      'profile_background_image_url' => 'http://a3.twimg.com/profile_background_images/104087198/04042010339.jpg',
+      'profile_background_image_url' => 'http://media.example.com/profile_background_images/104087198/04042010339.jpg',
       'favourites_count' => 5, 'created_at' => 'Fri Nov 20 21:58:19 +0000 2009',
       'is_translator' => false, 'contributors_enabled' => false, 'protected' => false,
       'follow_request_sent' => false, 'time_zone' => 'Greenland', 'profile_text_color' => '333333',
@@ -54,14 +54,14 @@ describe SorceryController, type: :controller do
     sorcery_controller_property_set(:external_providers, %i[twitter jira])
     sorcery_controller_external_property_set(:twitter, :key, 'eYVNBjBDi33aa9GkA3w')
     sorcery_controller_external_property_set(:twitter, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-    sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
+    sorcery_controller_external_property_set(:twitter, :callback_url, 'http://example.com')
 
     sorcery_controller_external_property_set(:jira, :key, '7810b8e317ebdc81601c72f8daecc0f1')
     sorcery_controller_external_property_set(:jira, :secret, 'MyAppUsingJira')
-    sorcery_controller_external_property_set(:jira, :site, 'http://jira.mycompany.com/plugins/servlet/oauth')
+    sorcery_controller_external_property_set(:jira, :site, 'http://jira.example.com/plugins/servlet/oauth')
     sorcery_controller_external_property_set(:jira, :signature_method, 'RSA-SHA1')
     sorcery_controller_external_property_set(:jira, :private_key_file, 'myrsakey.pem')
-    sorcery_controller_external_property_set(:jira, :callback_url, 'http://myappusingjira.com/home')
+    sorcery_controller_external_property_set(:jira, :callback_url, 'http://app.example.com/home')
   end
 
   # ----------------- OAuth -----------------------
@@ -71,7 +71,7 @@ describe SorceryController, type: :controller do
     end
 
     after do
-      sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:twitter, :callback_url, 'http://example.com')
       sorcery_controller_external_property_set(:twitter, :original_callback_url, nil)
     end
 
@@ -83,19 +83,19 @@ describe SorceryController, type: :controller do
       it 'login_at redirects correctly' do
         get :login_at_test
         expect(response).to be_a_redirect
-        expect(response).to redirect_to('http://myapi.com/oauth/authorize?oauth_callback=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&oauth_token=')
+        expect(response).to redirect_to('http://api.example.com/oauth/authorize?oauth_callback=http%3A%2F%2Ftest.host%2Foauth%2Ftwitter%2Fcallback&oauth_token=')
       end
     end
 
     context 'when callback_url begins with http://' do
       before do
-        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com/oauth/twitter/callback')
+        sorcery_controller_external_property_set(:twitter, :callback_url, 'http://example.com/oauth/twitter/callback')
       end
 
       it 'login_at redirects correctly' do
         get :login_at_test
         expect(response).to be_a_redirect
-        expect(response).to redirect_to('http://myapi.com/oauth/authorize?oauth_callback=http%3A%2F%2Fblabla.com%2Foauth%2Ftwitter%2Fcallback&oauth_token=')
+        expect(response).to redirect_to('http://api.example.com/oauth/authorize?oauth_callback=http%3A%2F%2Fexample.com%2Foauth%2Ftwitter%2Fcallback&oauth_token=')
       end
     end
 
@@ -163,7 +163,7 @@ describe SorceryController, type: :controller do
         sorcery_model_property_set(:authentications_class, UserProvider)
 
         allow(user).to receive_message_chain(:sorcery_config, :username_attribute_names, :first) { :username }
-        allow(user).to receive(:username).and_return('bla@bla.com')
+        allow(user).to receive(:username).and_return('bla@example.com')
         login_user(user)
 
         expect(user).to receive(:add_provider_to_user).with('twitter', '123')

--- a/spec/controllers/controller_remember_me_spec.rb
+++ b/spec/controllers/controller_remember_me_spec.rb
@@ -16,10 +16,10 @@ describe SorceryController, type: :controller do
     end
 
     it 'sets cookie on remember_me!' do
-      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
+      expect(User).to receive(:authenticate).with('bla@example.com', 'secret') { |&block| block.call(user, nil) }
       expect(user).to receive(:remember_me!)
 
-      post :test_login_with_remember, params: { email: 'bla@bla.com', password: 'secret' }
+      post :test_login_with_remember, params: { email: 'bla@example.com', password: 'secret' }
 
       expect(cookies.signed['remember_me_token']).to eq assigns[:current_user].remember_me_token
     end
@@ -39,11 +39,11 @@ describe SorceryController, type: :controller do
     end
 
     it 'login(email,password,remember_me) logs user in and remembers' do
-      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret', '1') { |&block| block.call(user, nil) }
+      expect(User).to receive(:authenticate).with('bla@example.com', 'secret', '1') { |&block| block.call(user, nil) }
       expect(user).to receive(:remember_me!)
       expect(user).to receive(:remember_me_token).and_return('abracadabra').twice
 
-      post :test_login_with_remember_in_login, params: { email: 'bla@bla.com', password: 'secret', remember: '1' }
+      post :test_login_with_remember_in_login, params: { email: 'bla@example.com', password: 'secret', remember: '1' }
 
       expect(cookies.signed['remember_me_token']).not_to be_nil
       expect(cookies.signed['remember_me_token']).to eq assigns[:user].remember_me_token
@@ -76,13 +76,13 @@ describe SorceryController, type: :controller do
     end
 
     it 'doest not remember_me! when not asked to, even if third parameter is used' do
-      post :test_login_with_remember_in_login, params: { email: 'bla@bla.com', password: 'secret', remember: '0' }
+      post :test_login_with_remember_in_login, params: { email: 'bla@example.com', password: 'secret', remember: '0' }
 
       expect(cookies['remember_me_token']).to be_nil
     end
 
     it 'doest not remember_me! when not asked to' do
-      post :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+      post :test_login, params: { email: 'bla@example.com', password: 'secret' }
       expect(cookies['remember_me_token']).to be_nil
     end
 

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -115,9 +115,9 @@ describe SorceryController, type: :controller do
     it 'works if the session is stored as a string or a Time' do
       session[:login_time] = Time.now.to_s
       # TODO: ???
-      expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
+      expect(User).to receive(:authenticate).with('bla@example.com', 'secret') { |&block| block.call(user, nil) }
 
-      get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+      get :test_login, params: { email: 'bla@example.com', password: 'secret' }
 
       expect(session[:user_id]).not_to be_nil
       expect(response).to be_successful
@@ -129,7 +129,7 @@ describe SorceryController, type: :controller do
       it 'does not logout if there was activity' do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
 
-        get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+        get :test_login, params: { email: 'bla@example.com', password: 'secret' }
         Timecop.travel(Time.now.in_time_zone + 0.3)
         get :test_should_be_logged_in
 
@@ -144,7 +144,7 @@ describe SorceryController, type: :controller do
 
       it "with 'session_timeout_from_last_action' logs out if there was no activity" do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
-        get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+        get :test_login, params: { email: 'bla@example.com', password: 'secret' }
         Timecop.travel(Time.now.in_time_zone + 0.6)
         get :test_should_be_logged_in
 

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -52,8 +52,8 @@ describe SorceryController, type: :controller do
     describe '#login' do
       context 'when succeeds' do
         before do
-          expect(User).to receive(:authenticate).with('bla@bla.com', 'secret') { |&block| block.call(user, nil) }
-          get :test_login, params: { email: 'bla@bla.com', password: 'secret' }
+          expect(User).to receive(:authenticate).with('bla@example.com', 'secret') { |&block| block.call(user, nil) }
+          get :test_login, params: { email: 'bla@example.com', password: 'secret' }
         end
 
         it 'assigns user to @user variable' do
@@ -67,8 +67,8 @@ describe SorceryController, type: :controller do
 
       context 'when fails' do
         before do
-          expect(User).to receive(:authenticate).with('bla@bla.com', 'opensesame!').and_return(nil)
-          get :test_login, params: { email: 'bla@bla.com', password: 'opensesame!' }
+          expect(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_return(nil)
+          get :test_login, params: { email: 'bla@example.com', password: 'opensesame!' }
         end
 
         it 'sets @user variable to nil' do
@@ -154,7 +154,7 @@ describe SorceryController, type: :controller do
 
     it 'on successful login the user is redirected to the url he originally wanted' do
       session[:return_to_url] = 'http://test.host/some_action'
-      post :test_return_to, params: { email: 'bla@bla.com', password: 'secret' }
+      post :test_return_to, params: { email: 'bla@example.com', password: 'secret' }
 
       expect(response).to redirect_to('http://test.host/some_action')
       expect(flash[:notice]).to eq 'haha!'

--- a/spec/shared_examples/user_brute_force_protection_shared_examples.rb
+++ b/spec/shared_examples/user_brute_force_protection_shared_examples.rb
@@ -107,7 +107,7 @@ shared_examples_for 'rails_3_brute_force_protection_model' do
       expect(lock_expires_at).not_to be_nil
 
       Timecop.travel(Time.now.in_time_zone + 0.3)
-      User.authenticate('bla@bla.com', 'secret')
+      User.authenticate('bla@example.com', 'secret')
 
       lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
       expect(lock_expires_at).to be_nil

--- a/spec/shared_examples/user_oauth_shared_examples.rb
+++ b/spec/shared_examples/user_oauth_shared_examples.rb
@@ -13,7 +13,7 @@ shared_examples_for 'rails_3_oauth_model' do
       sorcery_model_property_set(:authentications_class, Authentication)
       sorcery_controller_external_property_set(:twitter, :key, 'eYVNBjBDi33aa9GkA3w')
       sorcery_controller_external_property_set(:twitter, :secret, 'XpbeSdCoaKSmQGSeokz5qcUATClRW5u08QWNfv71N8')
-      sorcery_controller_external_property_set(:twitter, :callback_url, 'http://blabla.com')
+      sorcery_controller_external_property_set(:twitter, :callback_url, 'http://example.com')
     end
 
     it "responds to 'load_from_provider'" do

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -170,7 +170,7 @@ shared_examples_for 'rails_3_core_model' do
         end
 
         it 'yields the proper error if no user exists' do
-          [nil, '', 'not@a.user'].each do |email|
+          [nil, '', 'doesnotexists@example.com'].each do |email|
             User.authenticate(email, 'wrong!') do |user2, failure|
               expect(user2).to be_nil
               expect(failure).to eq :invalid_login
@@ -247,7 +247,7 @@ shared_examples_for 'rails_3_core_model' do
     end
 
     it 'does not encrypt the password twice when a user is updated' do
-      user.email = 'blup@bla.com'
+      user.email = 'blup@example.com'
       user.save
 
       expect(
@@ -302,7 +302,7 @@ shared_examples_for 'rails_3_core_model' do
 
   describe 'password validation' do
     let(:user_with_pass) do
-      create_new_user(username: 'foo_bar', email: 'foo@bar.com', password: 'foobar')
+      create_new_user(username: 'foo_bar', email: 'foo@example.com', password: 'foobar')
     end
 
     specify { expect(user_with_pass).to respond_to :valid_password? }
@@ -562,7 +562,7 @@ shared_examples_for 'rails_3_core_model' do
     end
 
     it 'find_by_email works as expected' do
-      expect(User.sorcery_adapter.find_by_email('bla@bla.com')).to eq user
+      expect(User.sorcery_adapter.find_by_email('bla@example.com')).to eq user
     end
   end
 end


### PR DESCRIPTION
Previously used domains like "blabla.com", "bla.com", and "bar.com" could exist in reality. Since IANA reserves example.com for documentation and examples, I replaced them with example.com whenever possible.

The exception is test.host, which Rails uses as the default domain in tests (see: https://github.com/rails/rails/blob/d09c4bbfcadcd6b3af847a11608a63c0718158ed/actionpack/lib/action_dispatch/testing/test_request.rb#L11). Simply changing it to example.com causes tests to fail. While adding the following snippet to `spec_helper.rb` would make the tests pass, I decided to leave it as is since the motivation isn’t strong enough:

```ruby
config.before(:each, type: :controller) do
  request.host = 'example.com'
end
```

related url: https://github.com/Sorcery/sorcery/pull/387#discussion_r2264873785
