### PR TITLE
Fix a test that expected Rails 8.0 but was using 8.1 instead

### DIFF
--- a/gemfiles/rails_80.gemfile
+++ b/gemfiles/rails_80.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 8.0'
+gem 'rails', '~> 8.0.0'
 gem 'rails-controller-testing'
 gem 'sqlite3', '~> 2.5.0'
 gem 'rspec-rails', '>= 6.1'


### PR DESCRIPTION
With the version constraint `~> 8.0`, Rails8.1 is now used since it has been released.
Changed it to `~> 8.0.0` so that only 8.0.x versions are used.
