### PR TITLE
Add a dependency on Rails 7.1 or higher

### DIFF
--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bcrypt', '~> 3.1'
   s.add_dependency 'oauth', '>= 0.6'
   s.add_dependency 'oauth2', '~> 2.0'
+  s.add_dependency 'railties', '>= 7.1'
 
   s.add_development_dependency 'byebug', '~> 11.1.3'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
In https://github.com/Sorcery/sorcery/pull/383￼, we dropped support for Rails versions below 7.1, but there was no way to enforce this requirement for Sorcery users. For example, it was still possible to use the latest version of Sorcery with Rails 6. To prevent issues caused by accidentally upgrading Sorcery while staying on an older version of Rails, we explicitly added a dependency on railties.

We depend on railties instead of rails to reduce the number of dependencies. The rails gem depends on all other Rails components like activerecord, but some developers intentionally avoid unused components in their applications. This change keeps the dependency minimal for those users.
