### PR TITLE
Remove Rails-version-based branchings that are no longer needed

### DIFF
--- a/lib/generators/sorcery/install_generator.rb
+++ b/lib/generators/sorcery/install_generator.rb
@@ -77,22 +77,13 @@ module Sorcery
 
       # Define the next_migration_number method (necessary for the migration_template method to work)
       def self.next_migration_number(dirname)
-        if timestamped_migrations?
+        if ActiveRecord.timestamped_migrations
           sleep 1 # make sure each time we get a different timestamp
           Time.new.utc.strftime('%Y%m%d%H%M%S')
         else
           format('%.3d', current_migration_number(dirname) + 1)
         end
       end
-
-      def self.timestamped_migrations?
-        if Rails::VERSION::MAJOR >= 7
-          ActiveRecord.timestamped_migrations
-        else
-          ActiveRecord::Base.timestamped_migrations
-        end
-      end
-      private_class_method :timestamped_migrations?
 
       private
 

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -198,12 +198,10 @@ describe SorceryController, type: :controller do
               .to receive(:referer).and_return('http://test.host/referer_action')
           end
 
-          context 'when Rails::VERSION::MAJOR >= 7', skip: Rails::VERSION::MAJOR < 7 do
-            it 'uses Rails 7 redirect_back_or_to method' do
-              get :test_redirect_back_or_to
+          it 'uses Rails 7 redirect_back_or_to method' do
+            get :test_redirect_back_or_to
 
-              expect(response).to redirect_to('http://test.host/referer_action')
-            end
+            expect(response).to redirect_to('http://test.host/referer_action')
           end
         end
 


### PR DESCRIPTION
Sorcery now supports Rails 7.1 and above, so conditional checks for Rails 7 or earlier are unnecessary.
