### PR TITLE
Make redirect_to_before_login_path capable of redirecting to other hosts

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -102,8 +102,11 @@ module Sorcery
         end
       end
 
-      def redirect_to_before_login_path(url, flash_hash = {})
-        redirect_to(session[:return_to_url] || url, flash: flash_hash)
+      def redirect_to_before_login_path(url, **options)
+        allow_other_host = options[:allow_other_host].nil? ? _allow_other_host : options[:allow_other_host]
+        flash = options.except(:allow_other_host)
+
+        redirect_to(session[:return_to_url] || url, flash:, allow_other_host:)
         session[:return_to_url] = nil
       end
 

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -227,5 +227,32 @@ describe SorceryController, type: :controller do
         end
       end
     end
+
+    describe '#redirect_to_before_login_path' do
+      context 'when allow_other_host is true' do
+        it 'redirects to external host' do
+          get :test_redirect_to_before_login_path_with_allow_other_host
+
+          expect(response).to redirect_to('http://external.example.com/')
+          expect(flash[:notice]).to eq 'redirected!'
+        end
+
+        it 'redirects to session[:return_to_url] if present' do
+          session[:return_to_url] = 'http://other.example.com/saved_path'
+          get :test_redirect_to_before_login_path_with_allow_other_host
+
+          expect(response).to redirect_to('http://other.example.com/saved_path')
+          expect(session[:return_to_url]).to be_nil
+        end
+      end
+
+      context 'when allow_other_host is false' do
+        it 'raises an error when redirecting to external host' do
+          expect do
+            get :test_redirect_to_before_login_path_without_allow_other_host
+          end.to raise_error(ActionController::Redirecting::UnsafeRedirectError, /Unsafe redirect/)
+        end
+      end
+    end
   end
 end

--- a/spec/rails_app/app/controllers/sorcery_controller.rb
+++ b/spec/rails_app/app/controllers/sorcery_controller.rb
@@ -45,6 +45,14 @@ class SorceryController < ApplicationController
     redirect_back_or_to(:index, notice: 'haha!')
   end
 
+  def test_redirect_to_before_login_path_with_allow_other_host
+    redirect_to_before_login_path('http://external.example.com/', notice: 'redirected!', allow_other_host: true)
+  end
+
+  def test_redirect_to_before_login_path_without_allow_other_host
+    redirect_to_before_login_path('http://external.example.com/', notice: 'redirected!', allow_other_host: false)
+  end
+
   def test_logout
     logout
     head :ok

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -7,6 +7,8 @@ AppRoot::Application.routes.draw do
     get :some_action
     post :test_return_to
     post :test_redirect_back_or_to
+    get :test_redirect_to_before_login_path_with_allow_other_host
+    get :test_redirect_to_before_login_path_without_allow_other_host
     get :test_auto_login
     post :test_login_with_remember_in_login
     get :test_login_from_cookie


### PR DESCRIPTION
Related PR: #351

Add an `allow_other_host` argument to the `redirect_to_before_login_path` method so it can redirect to other hosts. 
