### PR TITLE
Add instructions on how to release a gem in MAINTAINING.md

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -52,10 +52,9 @@ NOTE: `X.Y.Z` and `vX.Y.Z` are given as examples, and should be replaced with
 1. Stage your changes and create a commit
    1. `git add -A`
    1. `git commit -m "Release vX.Y.Z"`
-1. TODO: Gem Release (WIP)
+1. Gem Release
    1. `cd <dir>`
-   1. `gem build`
-   1. `gem push <filename>`
+   1. `bundle exec rake release`
 1. Create GitHub Release
    1. Create a new release via GitHub interface at https://github.com/Sorcery/sorcery/releases/new
    1. Use tag `vX.Y.Z` and title `vX.Y.Z`


### PR DESCRIPTION
I released a new gem myself and confirmed that `bundle exec rake release` works, so I added that to MAINTAINING.md.
I’m not sure what exactly should go in [this TODO section](https://github.com/Sorcery/sorcery/blob/1baeb219e7e15ad3b902b0e9dbdef48eaa616df5/MAINTAINING.md#L15-L17), so for now I only wrote what I could.