### PR TITLE
Remove unnecessary test configuration

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,6 @@ class TestMailer < ActionMailer::Base; end
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
-  config.include RSpec::Rails::ControllerExampleGroup, file_path: /controller(.)*_spec.rb$/
   config.mock_with :rspec
 
   config.use_transactional_fixtures = true
@@ -34,8 +33,4 @@ RSpec.configure do |config|
 
   config.include Sorcery::TestHelpers::Internal
   config.include Sorcery::TestHelpers::Internal::Rails
-
-  config.include Rails::Controller::Testing::TestProcess, type: :controller
-  config.include Rails::Controller::Testing::TemplateAssertions, type: :controller
-  config.include Rails::Controller::Testing::Integration, type: :controller
 end


### PR DESCRIPTION
rspec-rails automatically includes the required modules for tests tagged with `:controller`, so explicit include statements are not needed.

ref: https://github.com/rspec/rspec-rails/blob/f16a1639b5c2af5cde1ad1682b5c7a4af7f7b3df/lib/rspec/rails/configuration.rb#L47
ref: https://github.com/rspec/rspec-rails/blob/f16a1639b5c2af5cde1ad1682b5c7a4af7f7b3df/lib/rspec/rails/configuration.rb#L132-L134
