### PR TITLE
Ensure `Timecop.return` always runs after tests

### DIFF
--- a/spec/active_record/user_activation_spec.rb
+++ b/spec/active_record/user_activation_spec.rb
@@ -297,9 +297,9 @@ describe User, :active_record do
         sorcery_model_property_set(:activation_token_expiration_period, 0.1)
         user
 
-        Timecop.travel(Time.now.in_time_zone + 0.5)
-
-        expect(User.load_from_activation_token(user.activation_token)).to be_nil
+        Timecop.travel(Time.now.in_time_zone + 0.5) do
+          expect(User.load_from_activation_token(user.activation_token)).to be_nil
+        end
       end
 
       it 'load_from_activation_token returns nil if token is blank' do
@@ -342,11 +342,11 @@ describe User, :active_record do
             sorcery_model_property_set(:activation_token_expiration_period, 0.1)
             user
 
-            Timecop.travel(Time.now.in_time_zone + 0.5)
-
-            User.load_from_activation_token(user.activation_token) do |user2, failure|
-              expect(user2).to eq user
-              expect(failure).to eq :token_expired
+            Timecop.travel(Time.now.in_time_zone + 0.5) do
+              User.load_from_activation_token(user.activation_token) do |user2, failure|
+                expect(user2).to eq user
+                expect(failure).to eq :token_expired
+              end
             end
           end
 

--- a/spec/active_record/user_brute_force_protection_spec.rb
+++ b/spec/active_record/user_brute_force_protection_spec.rb
@@ -121,11 +121,12 @@ describe User, :active_record do
         lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
         expect(lock_expires_at).not_to be_nil
 
-        Timecop.travel(Time.now.in_time_zone + 0.3)
-        User.authenticate('bla@example.com', 'secret')
+        Timecop.travel(Time.now.in_time_zone + 0.3) do
+          User.authenticate('bla@example.com', 'secret')
 
-        lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
-        expect(lock_expires_at).to be_nil
+          lock_expires_at = User.sorcery_adapter.find_by_id(user.id).lock_expires_at
+          expect(lock_expires_at).to be_nil
+        end
       end
 
       it 'doest not unlock if time period is 0 (permanent lock)' do
@@ -135,11 +136,11 @@ describe User, :active_record do
         2.times { user.register_failed_login! }
 
         unlock_date = user.lock_expires_at
-        Timecop.travel(Time.now.in_time_zone + 1)
+        Timecop.travel(Time.now.in_time_zone + 1) do
+          user.register_failed_login!
 
-        user.register_failed_login!
-
-        expect(user.lock_expires_at.to_s).to eq unlock_date.to_s
+          expect(user.lock_expires_at.to_s).to eq unlock_date.to_s
+        end
       end
     end
 

--- a/spec/active_record/user_reset_password_spec.rb
+++ b/spec/active_record/user_reset_password_spec.rb
@@ -122,9 +122,9 @@ describe User, :active_record do
       it 'load_from_reset_password_token does NOT return user when token is found and expired' do
         sorcery_model_property_set(:reset_password_expiration_period, 0.1)
         user.generate_reset_password_token!
-        Timecop.travel(Time.now.in_time_zone + 0.5)
-
-        expect(User.load_from_reset_password_token(user.reset_password_token)).to be_nil
+        Timecop.travel(Time.now.in_time_zone + 0.5) do
+          expect(User.load_from_reset_password_token(user.reset_password_token)).to be_nil
+        end
       end
 
       it 'load_from_reset_password_token is always valid if expiration period is nil' do
@@ -175,11 +175,11 @@ describe User, :active_record do
           it 'yields user and failure reason when token is found and expired' do
             sorcery_model_property_set(:reset_password_expiration_period, 0.1)
             user.generate_reset_password_token!
-            Timecop.travel(Time.now.in_time_zone + 0.5)
-
-            User.load_from_reset_password_token(user.reset_password_token) do |user2, failure|
-              expect(user2).to eq user
-              expect(failure).to eq :token_expired
+            Timecop.travel(Time.now.in_time_zone + 0.5) do
+              User.load_from_reset_password_token(user.reset_password_token) do |user2, failure|
+                expect(user2).to eq user
+                expect(failure).to eq :token_expired
+              end
             end
           end
 
@@ -275,8 +275,9 @@ describe User, :active_record do
 
           expect(ActionMailer::Base.deliveries.size).to eq old_size + 1
 
-          Timecop.travel(Time.now.in_time_zone + 0.5)
-          user.deliver_reset_password_instructions!
+          Timecop.travel(Time.now.in_time_zone + 0.5) do
+            user.deliver_reset_password_instructions!
+          end
 
           expect(ActionMailer::Base.deliveries.size).to eq old_size + 2
         end
@@ -319,8 +320,9 @@ describe User, :active_record do
 
           expect(ActionMailer::Base.deliveries.size).to eq old_size
 
-          Timecop.travel(Time.now.in_time_zone + 0.5)
-          user.deliver_reset_password_instructions!
+          Timecop.travel(Time.now.in_time_zone + 0.5) do
+            user.deliver_reset_password_instructions!
+          end
 
           expect(ActionMailer::Base.deliveries.size).to eq old_size
         end

--- a/spec/controllers/controller_activity_logging_spec.rb
+++ b/spec/controllers/controller_activity_logging_spec.rb
@@ -28,22 +28,22 @@ describe SorceryController, type: :controller do
 
     it 'logs login time on login' do
       now = Time.now.in_time_zone
-      Timecop.freeze(now)
+      Timecop.freeze(now) do
+        sorcery_controller_property_set(:register_login_time, true)
+        login_user(user)
 
-      sorcery_controller_property_set(:register_login_time, true)
-      login_user(user)
-
-      expect(user.reload.last_login_at).to be_within(0.1).of(now)
+        expect(user.reload.last_login_at).to be_within(0.1).of(now)
+      end
     end
 
     it 'logs logout time on logout' do
       login_user(user)
       now = Time.now.in_time_zone
-      Timecop.freeze(now)
+      Timecop.freeze(now) do
+        logout_user
 
-      logout_user
-
-      expect(user.reload.last_logout_at).to be_within(0.1).of(now)
+        expect(user.reload.last_logout_at).to be_within(0.1).of(now)
+      end
     end
 
     it 'logs last activity time when logged in' do
@@ -51,11 +51,11 @@ describe SorceryController, type: :controller do
 
       login_user(user)
       now = Time.now.in_time_zone
-      Timecop.freeze(now)
+      Timecop.freeze(now) do
+        get :some_action
 
-      get :some_action
-
-      expect(user.reload.last_activity_at).to be_within(0.1).of(now)
+        expect(user.reload.last_activity_at).to be_within(0.1).of(now)
+      end
     end
 
     it 'logs last IP address when logged in' do

--- a/spec/controllers/controller_oauth2_spec.rb
+++ b/spec/controllers/controller_oauth2_spec.rb
@@ -314,19 +314,21 @@ describe SorceryController, :active_record, type: :controller do
 
         it 'registers login time' do
           now = Time.now.in_time_zone
-          Timecop.freeze(now)
-          expect(User).to receive(:load_from_provider).and_return(user)
-          expect(user).to receive(:set_last_login_at).with(be_within(0.1).of(now))
-          get :"test_login_from_#{provider}"
+          Timecop.freeze(now) do
+            expect(User).to receive(:load_from_provider).and_return(user)
+            expect(user).to receive(:set_last_login_at).with(be_within(0.1).of(now))
+            get :"test_login_from_#{provider}"
+          end
         end
 
         it 'does not register login time if configured so' do
           sorcery_controller_property_set(:register_login_time, false)
           now = Time.now.in_time_zone
-          Timecop.freeze(now)
-          expect(User).to receive(:load_from_provider).and_return(user)
-          expect(user).not_to receive(:set_last_login_at)
-          get :"test_login_from_#{provider}"
+          Timecop.freeze(now) do
+            expect(User).to receive(:load_from_provider).and_return(user)
+            expect(user).not_to receive(:set_last_login_at)
+            get :"test_login_from_#{provider}"
+          end
         end
       end
     end
@@ -359,11 +361,12 @@ describe SorceryController, :active_record, type: :controller do
           expect(User).to receive(:load_from_provider).with(provider.to_sym, '123').and_return(user)
           get :"test_login_from_#{provider}"
           expect(session[:user_id]).to eq user.id.to_s
-          Timecop.travel(Time.now.in_time_zone + 0.6)
-          get :test_should_be_logged_in
+          Timecop.travel(Time.now.in_time_zone + 0.6) do
+            get :test_should_be_logged_in
 
-          expect(session[:user_id]).to be_nil
-          expect(response).to be_a_redirect
+            expect(session[:user_id]).to be_nil
+            expect(response).to be_a_redirect
+          end
         end
       end
     end

--- a/spec/controllers/controller_oauth_spec.rb
+++ b/spec/controllers/controller_oauth_spec.rb
@@ -203,19 +203,21 @@ describe SorceryController, type: :controller do
 
       it 'registers login time' do
         now = Time.now.in_time_zone
-        Timecop.freeze(now)
-        expect(User).to receive(:load_from_provider).and_return(user)
-        expect(user).to receive(:set_last_login_at).with(be_within(0.1).of(now))
-        get :test_login_from
+        Timecop.freeze(now) do
+          expect(User).to receive(:load_from_provider).and_return(user)
+          expect(user).to receive(:set_last_login_at).with(be_within(0.1).of(now))
+          get :test_login_from
+        end
       end
 
       it 'does not register login time if configured so' do
         sorcery_controller_property_set(:register_login_time, false)
         now = Time.now.in_time_zone
-        Timecop.freeze(now)
-        expect(User).to receive(:load_from_provider).and_return(user)
-        expect(user).not_to receive(:set_last_login_at)
-        get :test_login_from
+        Timecop.freeze(now) do
+          expect(User).to receive(:load_from_provider).and_return(user)
+          expect(user).not_to receive(:set_last_login_at)
+          get :test_login_from
+        end
       end
     end
   end
@@ -247,11 +249,12 @@ describe SorceryController, type: :controller do
 
       it 'resets session after session timeout' do
         get :test_login_from
-        Timecop.travel(Time.now.in_time_zone + 0.6)
-        get :test_should_be_logged_in
+        Timecop.travel(Time.now.in_time_zone + 0.6) do
+          get :test_should_be_logged_in
 
-        expect(session[:user_id]).to be_nil
-        expect(response).to be_a_redirect
+          expect(session[:user_id]).to be_nil
+          expect(response).to be_a_redirect
+        end
       end
     end
   end

--- a/spec/controllers/controller_session_timeout_spec.rb
+++ b/spec/controllers/controller_session_timeout_spec.rb
@@ -22,11 +22,12 @@ describe SorceryController, type: :controller do
 
     it 'resets session after session timeout' do
       login_user user
-      Timecop.travel(Time.now.in_time_zone + 0.6)
-      get :test_should_be_logged_in
+      Timecop.travel(Time.now.in_time_zone + 0.6) do
+        get :test_should_be_logged_in
 
-      expect(session[:user_id]).to be_nil
-      expect(response).to be_a_redirect
+        expect(session[:user_id]).to be_nil
+        expect(response).to be_a_redirect
+      end
     end
 
     context "with 'invalidate_active_sessions_enabled'" do
@@ -128,26 +129,29 @@ describe SorceryController, type: :controller do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
 
         get :test_login, params: { email: 'bla@example.com', password: 'secret' }
-        Timecop.travel(Time.now.in_time_zone + 0.3)
-        get :test_should_be_logged_in
+        Timecop.travel(Time.now.in_time_zone + 0.3) do
+          get :test_should_be_logged_in
 
-        expect(session[:user_id]).not_to be_nil
+          expect(session[:user_id]).not_to be_nil
+        end
 
-        Timecop.travel(Time.now.in_time_zone + 0.3)
-        get :test_should_be_logged_in
+        Timecop.travel(Time.now.in_time_zone + 0.3) do
+          get :test_should_be_logged_in
 
-        expect(session[:user_id]).not_to be_nil
-        expect(response).to be_successful
+          expect(session[:user_id]).not_to be_nil
+          expect(response).to be_successful
+        end
       end
 
       it "with 'session_timeout_from_last_action' logs out if there was no activity" do
         sorcery_controller_property_set(:session_timeout_from_last_action, true)
         get :test_login, params: { email: 'bla@example.com', password: 'secret' }
-        Timecop.travel(Time.now.in_time_zone + 0.6)
-        get :test_should_be_logged_in
+        Timecop.travel(Time.now.in_time_zone + 0.6) do
+          get :test_should_be_logged_in
 
-        expect(session[:user_id]).to be_nil
-        expect(response).to be_a_redirect
+          expect(session[:user_id]).to be_nil
+          expect(response).to be_a_redirect
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ RSpec.configure do |config|
   config.before(:suite) { setup_orm }
   config.after(:suite) { teardown_orm }
   config.before { ActionMailer::Base.deliveries.clear }
-  config.after { Timecop.return }
 
   config.include Sorcery::TestHelpers::Internal
   config.include Sorcery::TestHelpers::Internal::Rails


### PR DESCRIPTION
Some tests use `Timecop.freeze` but do not call `Timecop.return` afterward (e.g. the test in https://github.com/Sorcery/sorcery/blob/4e77ab2e379fd5d938f42a59b17696ad048fed25/spec/controllers/controller_oauth2_spec.rb#L324-L331 ).

This can cause flaky tests, so always call `Timecop.return` in the teardown for all tests.
