### PR TITLE
Remove redundant Hash#destroy patch from Internal TestHelpers

### DIFF
--- a/lib/sorcery/test_helpers/internal.rb
+++ b/lib/sorcery/test_helpers/internal.rb
@@ -16,15 +16,6 @@ module Sorcery
         end
       end
 
-      # a patch to fix a bug in testing that happens when you 'destroy' a session twice.
-      # After the first destroy, the session is an ordinary hash, and then when destroy
-      # is called again there's an exception.
-      class ::Hash
-        def destroy
-          clear
-        end
-      end
-
       def build_new_user(attributes_hash = nil)
         user_attributes_hash = attributes_hash || { username: 'gizmo', email: 'bla@example.com', password: 'secret' }
         @user = User.new(user_attributes_hash)


### PR DESCRIPTION
The monkey patch for `Hash#destroy` is introduced in this commit.
[https://github.com/NoamB/sorcery/commit/f8646b77ca5eee9f7dad47d67047f4119f4f262b#diff-769521652f47338fa5a75da5a8fa4bedd213e348549d390d46bb6eac8c826bb7R3-R10](https://github.com/NoamB/sorcery/commit/f8646b77ca5eee9f7dad47d67047f4119f4f262b#diff-769521652f47338fa5a75da5a8fa4bedd213e348549d390d46bb6eac8c826bb7R3-R10)

I assume it is added to avoid this issue.

[NoMethodError: undefined method `destroy_session' for nil:NilClass · Issue #464 · NoamB/sorcery](https://github.com/NoamB/sorcery/issues/464)

However, this is a problem only up to Rails 4.0.
In Rails 4.1, the following change is introduced and the exception no longer occurs.

[Calling reset_session inside of a controller with a NullSessionHash raises a nil exception. by jbaudanza · Pull Request #12279 · rails/rails](https://github.com/rails/rails/pull/12279)

Because of this, this monkey patch is no longer needed now.
