### PR TITLE
Add coverage artifacts to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,8 @@ jobs:
           - '81'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
+      COVERAGE: 'true'
+      COVERAGE_DIR: coverage/ruby_${{ matrix.ruby }}_rails_${{ matrix.rails }}
     steps:
       - uses: actions/checkout@v5
       - name: Set up Ruby
@@ -35,6 +37,13 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake spec
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-ruby-${{ matrix.ruby }}-rails-${{ matrix.rails }}
+          path: coverage/
+          if-no-files-found: ignore
 
   rubocop:
     runs-on: ubuntu-latest

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'byebug', '~> 11.1.3'
   s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'simplecov', '~> 0.22.0'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'webmock', '~> 3.3.0'
   s.add_development_dependency 'yard', '~> 0.9.0', '>= 0.9.12'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+if ENV['COVERAGE'] == 'true'
+  require 'simplecov'
+
+  SimpleCov.start do
+    enable_coverage :branch
+    coverage_dir ENV.fetch('COVERAGE_DIR', 'coverage')
+    add_filter '/spec/'
+    add_filter '/gemfiles/'
+    track_files 'lib/**/*.rb'
+  end
+end
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 


### PR DESCRIPTION
Enable SimpleCov for spec runs and upload per-matrix coverage reports from GitHub Actions so CI exposes line and branch coverage output.
