### PR TITLE
Prevent login! failure blocks from masking InvalidCredentials

### DIFF
--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -59,12 +59,12 @@ module Sorcery
         end
       end
 
-      def login!(...)
-        user = login(...)
+      def login!(*credentials)
+        user = login(*credentials)
 
         raise Sorcery::InvalidCredentials if user.nil?
 
-        user
+        block_given? ? yield(user, nil) : user
       end
 
       def reset_sorcery_session

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -64,7 +64,9 @@ module Sorcery
 
         raise Sorcery::InvalidCredentials if user.nil?
 
-        block_given? ? yield(user, nil) : user
+        yield(user, nil) if block_given?
+
+        user
       end
 
       def reset_sorcery_session

--- a/spec/controllers/sorcery_controller_spec.rb
+++ b/spec/controllers/sorcery_controller_spec.rb
@@ -107,7 +107,7 @@ describe SorceryController, type: :controller do
 
       context 'when fails' do
         before do
-          allow(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_yield(user, :invalid_password)
+          allow(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_return(nil)
         end
 
         it 'raises InvalidCredentials exception' do
@@ -129,6 +129,10 @@ describe SorceryController, type: :controller do
           expect(session[:user_id]).to eq user.id.to_s
         end
 
+        it 'assigns user to @user variable' do
+          expect(assigns[:user]).to eq user
+        end
+
         it 'redirects to root' do
           expect(response).to redirect_to(root_url)
         end
@@ -136,7 +140,7 @@ describe SorceryController, type: :controller do
 
       context 'when fails' do
         before do
-          allow(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_return(nil)
+          allow(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_yield(user, :invalid_password)
         end
 
         it 'raises InvalidCredentials exception' do

--- a/spec/controllers/sorcery_controller_spec.rb
+++ b/spec/controllers/sorcery_controller_spec.rb
@@ -107,7 +107,7 @@ describe SorceryController, type: :controller do
 
       context 'when fails' do
         before do
-          allow(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_return(nil)
+          allow(User).to receive(:authenticate).with('bla@example.com', 'opensesame!').and_yield(user, :invalid_password)
         end
 
         it 'raises InvalidCredentials exception' do


### PR DESCRIPTION
This PR fixes a bug that I found while trying to remove the mock in #438. 

login! is documented to raise Sorcery::InvalidCredentials when authentication fails. When authenticate yields a failure reason, forwarding the caller's block to login lets controller code in the failure branch run before login! can raise, so errors such as a missing template can replace InvalidCredentials.

Call login without forwarding the block, then yield to the caller only after a successful authentication. This keeps login's failure-reason block behavior intact while preserving login!'s raise-on-failure contract.

Please ensure your pull request includes the following:

- [x] Description of changes
- [x] Changes have related RSpec tests that ensure functionality does not break
