### PR TITLE
Move development dependencies to Gemfile

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 5
-# Configuration parameters: EnforcedStyle, AllowedGems.
-# SupportedStyles: Gemfile, gems.rb, gemspec
-Gemspec/DevelopmentDependencies:
-  Exclude:
-    - 'sorcery.gemspec'
-
 # Offense count: 66
 RSpec/BeforeAfterAll:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,18 @@
 
 source 'https://rubygems.org'
 
+gem 'byebug', '~> 11.1.3'
 gem 'pry'
 gem 'rails'
 gem 'rails-controller-testing'
+gem 'rspec-rails'
 gem 'rubocop', '~> 1.81.1', require: false
 gem 'rubocop-performance', '~> 1.26.0', require: false
 gem 'rubocop-rspec', '~> 3.7.0', require: false
+gem 'simplecov', '~> 0.22.0'
 gem 'sqlite3'
+gem 'timecop'
+gem 'webmock', '~> 3.3.0'
+gem 'yard', '~> 0.9.0', '>= 0.9.12'
 
 gemspec

--- a/gemfiles/rails_71.gemfile
+++ b/gemfiles/rails_71.gemfile
@@ -2,8 +2,12 @@
 
 source 'https://rubygems.org'
 
+gem 'byebug', '~> 11.1.3'
 gem 'rails', '~> 7.1.0'
 gem 'rails-controller-testing'
 gem 'rspec-rails', '>= 6.1'
+gem 'simplecov', '~> 0.22.0'
 gem 'sqlite3', '~> 1.4'
+gem 'timecop'
+gem 'webmock', '~> 3.3.0'
 gemspec path: '..'

--- a/gemfiles/rails_72.gemfile
+++ b/gemfiles/rails_72.gemfile
@@ -2,8 +2,12 @@
 
 source 'https://rubygems.org'
 
+gem 'byebug', '~> 11.1.3'
 gem 'rails', '~> 7.2.2.1'
 gem 'rails-controller-testing'
 gem 'rspec-rails', '>= 6.1'
+gem 'simplecov', '~> 0.22.0'
 gem 'sqlite3', '~> 2.5.0'
+gem 'timecop'
+gem 'webmock', '~> 3.3.0'
 gemspec path: '..'

--- a/gemfiles/rails_80.gemfile
+++ b/gemfiles/rails_80.gemfile
@@ -2,8 +2,12 @@
 
 source 'https://rubygems.org'
 
+gem 'byebug', '~> 11.1.3'
 gem 'rails', '~> 8.0.0'
 gem 'rails-controller-testing'
 gem 'rspec-rails', '>= 6.1'
+gem 'simplecov', '~> 0.22.0'
 gem 'sqlite3', '~> 2.5.0'
+gem 'timecop'
+gem 'webmock', '~> 3.3.0'
 gemspec path: '..'

--- a/gemfiles/rails_81.gemfile
+++ b/gemfiles/rails_81.gemfile
@@ -2,8 +2,12 @@
 
 source 'https://rubygems.org'
 
+gem 'byebug', '~> 11.1.3'
 gem 'rails', '~> 8.1.0'
 gem 'rails-controller-testing'
 gem 'rspec-rails', '>= 8.0.0'
+gem 'simplecov', '~> 0.22.0'
 gem 'sqlite3', '~> 2.5.0'
+gem 'timecop'
+gem 'webmock', '~> 3.3.0'
 gemspec path: '..'

--- a/sorcery.gemspec
+++ b/sorcery.gemspec
@@ -38,11 +38,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'oauth', '>= 0.6'
   s.add_dependency 'oauth2', '~> 2.0'
   s.add_dependency 'railties', '>= 7.1'
-
-  s.add_development_dependency 'byebug', '~> 11.1.3'
-  s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'simplecov', '~> 0.22.0'
-  s.add_development_dependency 'timecop'
-  s.add_development_dependency 'webmock', '~> 3.3.0'
-  s.add_development_dependency 'yard', '~> 0.9.0', '>= 0.9.12'
 end


### PR DESCRIPTION
## Summary

- Move the six development-only gem declarations from `sorcery.gemspec` to `Gemfile`.
- Preserve every existing version constraint.
- Remove only the resolved `Gemspec/DevelopmentDependencies` entry from `.rubocop_todo.yml`.

This handles one remaining cop from #396 in a single commit. Runtime dependencies and packaged files are unchanged.

## Validation

- `bundle check`
- Targeted `Gemspec/DevelopmentDependencies` check: 0 offenses
- Full RuboCop: 123 files, 0 offenses
- Full RSpec: 559 examples, 0 failures
- `gem build sorcery.gemspec`: successful
- `git diff --check`
